### PR TITLE
Add missing permission to check_libs.yaml

### DIFF
--- a/.github/workflows/check_libs.yaml
+++ b/.github/workflows/check_libs.yaml
@@ -37,3 +37,5 @@ jobs:
           charm-path: ${{ matrix.path }}
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+    permissions:
+      issues: write  # Needed to edit pull request labels


### PR DESCRIPTION
Repository is configured to use permission-less GITHUB_TOKEN by default (instead of granting write for all permissions)

i.e. "Read repository contents and packages permissions" instead of "Read and write permissions" for "Workflow permissions" setting
> Choose the default permissions granted to the GITHUB_TOKEN when running workflows in this repository. You can specify more granular permissions in the workflow using YAML.
