### PR TITLE
Fix Allure Report

### DIFF
--- a/machines/spread.yaml
+++ b/machines/spread.yaml
@@ -96,7 +96,7 @@ backends:
       - ubuntu-24.04-arm:
           username: runner
           variants:
-            - -juju29_ubuntu22
+            - -juju29
 
 suites:
   tests/spread/:
@@ -107,9 +107,9 @@ path: /root/spread_project
 kill-timeout: 3h
 environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
-  CONCIERGE_JUJU_CHANNEL/juju36_ubuntu22: 3.6/stable
-  CONCIERGE_JUJU_CHANNEL/juju29_ubuntu22: 2.9/stable
-  CHARM_UBUNTU_BASE/juju36_ubuntu22,juju29_ubuntu22: 22.04
+  CONCIERGE_JUJU_CHANNEL/juju36: 3.6/stable
+  CONCIERGE_JUJU_CHANNEL/juju29: 2.9/stable
+  CHARM_UBUNTU_BASE/juju36,juju29: 22.04
 prepare: |
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"


### PR DESCRIPTION
Rename machines spread variants to match Kubernetes spread variants

Machines results missing from https://canonical.github.io/mysql-router-operators/7/

This may not fully fix the Allure Report—it looks like if the relative path to the test file and the test name is the same, the test case ID may be identical, so for those tests vm/k8s may override each other. However, this should at least fix zero results for machines showing up in the Allure Report