### PR TITLE
Add missing `fail-fast: false` to workflow

### DIFF
--- a/.github/workflows/integration_test_charms.yaml
+++ b/.github/workflows/integration_test_charms.yaml
@@ -12,6 +12,7 @@ on:
 jobs:
   integration-test:
     strategy:
+      fail-fast: false
       matrix:
         path:
           - kubernetes


### PR DESCRIPTION
Integration tests are flaky and in-progress jobs should not be cancelled if one fails

Match https://github.com/canonical/mysql-router-operators/blob/9e6811626937f7c5a67d90c06245e2a140adecf9/.github/workflows/integration_test_charm.yaml#L86
