### PR TITLE
[DPE-7322] Support predefined roles

### DIFF
--- a/common/common/mysql_shell/__init__.py
+++ b/common/common/mysql_shell/__init__.py
@@ -13,7 +13,6 @@ import pathlib
 import typing
 
 import jinja2
-import tenacity
 
 from .. import container, server_exceptions, utils
 
@@ -181,13 +180,12 @@ class Shell:
         if database in self._get_mysql_databases():
             return
 
-        rolename = self._build_application_database_dba_role(database)
-
+        role_name = self._build_application_database_dba_role(database)
         statements = [
-            f"CREATE ROLE `{rolename}`",
+            f"CREATE ROLE `{role_name}`",
             f"CREATE DATABASE `{database}`",
-            f"GRANT SELECT, INSERT, DELETE, UPDATE, EXECUTE ON `{database}`.* TO {rolename}",
-            f"GRANT ALTER, ALTER ROUTINE, CREATE, CREATE ROUTINE, CREATE VIEW, DROP, INDEX, LOCK TABLES, REFERENCES, TRIGGER ON `{database}`.* TO {rolename}",
+            f"GRANT SELECT, INSERT, DELETE, UPDATE, EXECUTE ON `{database}`.* TO {role_name}",
+            f"GRANT ALTER, ALTER ROUTINE, CREATE, CREATE ROUTINE, CREATE VIEW, DROP, INDEX, LOCK TABLES, REFERENCES, TRIGGER ON `{database}`.* TO {role_name}",
         ]
 
         mysql_roles = self._get_mysql_roles("charmed_%")
@@ -218,15 +216,7 @@ class Shell:
 
     def create_application_database(self, *, database: str, username: str) -> str:
         """Create both the database and the relation user, returning its password."""
-        for attempt in tenacity.Retrying(
-            retry=tenacity.retry_if_exception_type(ShellDBError),
-            reraise=True,
-            stop=tenacity.stop_after_delay(30),
-            wait=tenacity.wait_fixed(5),
-        ):
-            with attempt:
-                self._create_application_database(database=database)
-
+        self._create_application_database(database=database)
         return self._create_application_user(database=database, username=username)
 
     def add_attributes_to_mysql_router_user(

--- a/common/common/mysql_shell/__init__.py
+++ b/common/common/mysql_shell/__init__.py
@@ -19,6 +19,12 @@ from .. import container, server_exceptions, utils
 if typing.TYPE_CHECKING:
     from ..relations import database_requires
 
+_ROLE_DML = "charmed_dml"
+_ROLE_READ = "charmed_read"
+
+ROLE_DBA_PREFIX = "charmed_dba"
+ROLE_MAX_LENGTH = 32
+
 logger = logging.getLogger(__name__)
 
 
@@ -123,17 +129,67 @@ class Shell:
             attributes.update(additional_attributes)
         return json.dumps(attributes)
 
-    def create_application_database_and_user(self, *, username: str, database: str) -> str:
-        """Create database and user for related database_provides application."""
-        attributes = self._get_attributes()
-        logger.debug(f"Creating {database=} and {username=} with {attributes=}")
-        password = utils.generate_password()
-        self._run_sql([
+    # TODO python3.10 min version: Use `set` instead of `typing.Set`
+    def _get_mysql_roles(self, name_pattern: str) -> typing.Set[str]:
+        """Returns a set with the MySQL roles."""
+        logger.debug(f"Getting MySQL roles with {name_pattern=}")
+        output_file = self._container.path("/tmp/mysqlsh_output.json")
+        self._run_code(
+            _jinja_env.get_template("get_mysql_roles_with_pattern.py.jinja").render(
+                name_pattern=name_pattern,
+                output_filepath=output_file.relative_to_container,
+            )
+        )
+        with output_file.open("r") as file:
+            rows = json.load(file)
+        output_file.unlink()
+        logger.debug(f"MySQL roles found for {name_pattern=}: {len(rows)}")
+        return {row[0] for row in rows}
+
+    def _create_application_database(self, *, database: str, rolename: str) -> str:
+        """Create database for related database_provides application."""
+        statements = [
             f"CREATE DATABASE IF NOT EXISTS `{database}`",
+            f"CREATE ROLE IF NOT EXISTS `{rolename}`",
+            f"GRANT SELECT, INSERT, DELETE, UPDATE, EXECUTE ON `{database}`.* TO {rolename}",
+            f"GRANT ALTER, ALTER ROUTINE, CREATE, CREATE ROUTINE, CREATE VIEW, DROP, INDEX, LOCK TABLES, REFERENCES, TRIGGER ON `{database}`.* TO {rolename}",
+        ]
+
+        mysql_roles = self._get_mysql_roles("charmed_%")
+        if _ROLE_READ in mysql_roles:
+            statements.append(
+                f"GRANT SELECT ON `{database}`.* TO {_ROLE_READ}",
+            )
+        if _ROLE_DML in mysql_roles:
+            statements.append(
+                f"GRANT SELECT, INSERT, DELETE, UPDATE ON `{database}`.* TO {_ROLE_DML}",
+            )
+
+        logger.debug(f"Creating {database=}")
+        self._run_sql(statements)
+        logger.debug(f"Created {database=}")
+        return database
+
+    def _create_application_user(self, *, database: str, username: str) -> str:
+        """Create database user for related database_provides application."""
+        attributes = self._get_attributes()
+        password = utils.generate_password()
+        logger.debug(f"Creating {username=} with {attributes=}")
+        self._run_sql([
             f"CREATE USER `{username}` IDENTIFIED BY '{password}' ATTRIBUTE '{attributes}'",
             f"GRANT ALL PRIVILEGES ON `{database}`.* TO `{username}`",
         ])
-        logger.debug(f"Created {database=} and {username=} with {attributes=}")
+        logger.debug(f"Created {username=} with {attributes=}")
+        return password
+
+    def create_application_database(self, *, database: str, username: str) -> str:
+        """Create both the database and the relation user, returning its password."""
+        rolename = f"{ROLE_DBA_PREFIX}_{database}"
+        if len(rolename) >= ROLE_MAX_LENGTH:
+            raise ValueError("Database DBA role longer than 32 characters")
+
+        ________ = self._create_application_database(database=database, rolename=rolename)
+        password = self._create_application_user(database=database, username=username)
         return password
 
     def add_attributes_to_mysql_router_user(

--- a/common/common/mysql_shell/__init__.py
+++ b/common/common/mysql_shell/__init__.py
@@ -13,6 +13,7 @@ import pathlib
 import typing
 
 import jinja2
+import tenacity
 
 from .. import container, server_exceptions, utils
 
@@ -21,9 +22,7 @@ if typing.TYPE_CHECKING:
 
 _ROLE_DML = "charmed_dml"
 _ROLE_READ = "charmed_read"
-
-ROLE_DBA_PREFIX = "charmed_dba"
-ROLE_MAX_LENGTH = 32
+_ROLE_MAX_LENGTH = 32
 
 logger = logging.getLogger(__name__)
 
@@ -130,6 +129,22 @@ class Shell:
         return json.dumps(attributes)
 
     # TODO python3.10 min version: Use `set` instead of `typing.Set`
+    def _get_mysql_databases(self) -> typing.Set[str]:
+        """Returns a set with the MySQL databases."""
+        logger.debug(f"Getting MySQL databases")
+        output_file = self._container.path("/tmp/mysqlsh_output.json")
+        self._run_code(
+            _jinja_env.get_template("get_mysql_databases.py.jinja").render(
+                output_filepath=output_file.relative_to_container,
+            )
+        )
+        with output_file.open("r") as file:
+            rows = json.load(file)
+        output_file.unlink()
+        logger.debug(f"MySQL databases found: {len(rows)}")
+        return {row[0] for row in rows}
+
+    # TODO python3.10 min version: Use `set` instead of `typing.Set`
     def _get_mysql_roles(self, name_pattern: str) -> typing.Set[str]:
         """Returns a set with the MySQL roles."""
         logger.debug(f"Getting MySQL roles with {name_pattern=}")
@@ -146,11 +161,31 @@ class Shell:
         logger.debug(f"MySQL roles found for {name_pattern=}: {len(rows)}")
         return {row[0] for row in rows}
 
-    def _create_application_database(self, *, database: str, rolename: str) -> str:
+    def _build_application_database_dba_role(self, database: str) -> str:
+        """Builds the database-level DBA role, given length constraints."""
+        role_prefix = "charmed_dba"
+        role_suffix = "XX"
+
+        role_name_available = _ROLE_MAX_LENGTH - len(role_prefix) - len(role_suffix) - 2
+        role_name_description = database[:role_name_available]
+        role_name_collisions = self._get_mysql_roles(f"{role_prefix}_{role_name_description}_%")
+
+        return "_".join((
+            role_prefix,
+            role_name_description,
+            str(len(role_name_collisions)).zfill(len(role_suffix)),
+        ))
+
+    def _create_application_database(self, *, database: str) -> None:
         """Create database for related database_provides application."""
+        if database in self._get_mysql_databases():
+            return
+
+        rolename = self._build_application_database_dba_role(database)
+
         statements = [
-            f"CREATE DATABASE IF NOT EXISTS `{database}`",
-            f"CREATE ROLE IF NOT EXISTS `{rolename}`",
+            f"CREATE ROLE `{rolename}`",
+            f"CREATE DATABASE `{database}`",
             f"GRANT SELECT, INSERT, DELETE, UPDATE, EXECUTE ON `{database}`.* TO {rolename}",
             f"GRANT ALTER, ALTER ROUTINE, CREATE, CREATE ROUTINE, CREATE VIEW, DROP, INDEX, LOCK TABLES, REFERENCES, TRIGGER ON `{database}`.* TO {rolename}",
         ]
@@ -168,7 +203,6 @@ class Shell:
         logger.debug(f"Creating {database=}")
         self._run_sql(statements)
         logger.debug(f"Created {database=}")
-        return database
 
     def _create_application_user(self, *, database: str, username: str) -> str:
         """Create database user for related database_provides application."""
@@ -184,13 +218,16 @@ class Shell:
 
     def create_application_database(self, *, database: str, username: str) -> str:
         """Create both the database and the relation user, returning its password."""
-        rolename = f"{ROLE_DBA_PREFIX}_{database}"
-        if len(rolename) >= ROLE_MAX_LENGTH:
-            raise ValueError("Database DBA role longer than 32 characters")
+        for attempt in tenacity.Retrying(
+            retry=tenacity.retry_if_exception_type(ShellDBError),
+            reraise=True,
+            stop=tenacity.stop_after_delay(30),
+            wait=tenacity.wait_fixed(5),
+        ):
+            with attempt:
+                self._create_application_database(database=database)
 
-        ________ = self._create_application_database(database=database, rolename=rolename)
-        password = self._create_application_user(database=database, username=username)
-        return password
+        return self._create_application_user(database=database, username=username)
 
     def add_attributes_to_mysql_router_user(
         self, *, username: str, router_id: str, unit_name: str

--- a/common/common/mysql_shell/templates/get_mysql_databases.py.jinja
+++ b/common/common/mysql_shell/templates/get_mysql_databases.py.jinja
@@ -1,0 +1,10 @@
+import json
+
+result = session.run_sql("SHOW DATABASES")
+rows = result.fetch_all()
+# mysqlsh objects are weird—they quack (i.e. duck typing) like standard Python objects (e.g. list,
+# dict), but do not serialize to JSON correctly.
+# Cast to str & load from JSON str before serializing
+rows = json.loads(str(rows))
+with open("{{ output_filepath }}", "w") as file:
+    json.dump(rows, file)

--- a/common/common/mysql_shell/templates/get_mysql_roles_with_pattern.py.jinja
+++ b/common/common/mysql_shell/templates/get_mysql_roles_with_pattern.py.jinja
@@ -1,0 +1,12 @@
+import json
+
+result = session.run_sql(
+    "SELECT user FROM mysql.user WHERE user LIKE '{{ name_pattern }}'"
+)
+rows = result.fetch_all()
+# mysqlsh objects are weird—they quack (i.e. duck typing) like standard Python objects (e.g. list,
+# dict), but do not serialize to JSON correctly.
+# Cast to str & load from JSON str before serializing
+rows = json.loads(str(rows))
+with open("{{ output_filepath }}", "w") as file:
+    json.dump(rows, file)

--- a/common/common/relations/database_provides.py
+++ b/common/common/relations/database_provides.py
@@ -30,23 +30,10 @@ class _UnsupportedExtraUserRole(status_exception.StatusException):
 
     def __init__(self, *, app_name: str, endpoint_name: str) -> None:
         message = (
-            f"{app_name} app requested unsupported extra user role on "
-            f"{endpoint_name} endpoint"
+            f"{app_name} app requested unsupported extra user role on {endpoint_name} endpoint"
         )
         logger.warning(message)
         super().__init__(ops.BlockedStatus(message))
-
-
-class _InvalidDatabaseName(status_exception.StatusException):
-    """Application charm requested an invalid database name"""
-
-    def __init__(self, *, app_name: str, endpoint_name: str, exception_msg: str) -> None:
-        message = (
-            f"{app_name} app requested an invalid database name on "
-            f"{endpoint_name} endpoint: {exception_msg}"
-        )
-        logger.warning(message)
-        super().__init__(ops.BlockedStatus(exception_msg))
 
 
 class _Relation:
@@ -92,19 +79,9 @@ class _RelationThatRequestedUser(_Relation):
         if isinstance(event, ops.RelationBrokenEvent) and event.relation.id == self._id:
             raise _RelationBreaking
         self._database: str = self._databag["database"]
-        self._app_name: str = relation.app.name
-        self._endpoint_name: str = relation.name
-        database_dba_role = f"{mysql_shell.ROLE_DBA_PREFIX}_{self._database}"
-        if len(database_dba_role) >= mysql_shell.ROLE_MAX_LENGTH:
-            raise _InvalidDatabaseName(
-                app_name=self._app_name,
-                endpoint_name=self._endpoint_name,
-                exception_msg="Database DBA role longer than 32 characters",
-            )
         if self._databag.get("extra-user-roles"):
             raise _UnsupportedExtraUserRole(
-                app_name=self._app_name,
-                endpoint_name=self._endpoint_name,
+                app_name=relation.app.name, endpoint_name=relation.name
             )
 
     def _set_databag(

--- a/common/common/relations/database_provides.py
+++ b/common/common/relations/database_provides.py
@@ -30,10 +30,23 @@ class _UnsupportedExtraUserRole(status_exception.StatusException):
 
     def __init__(self, *, app_name: str, endpoint_name: str) -> None:
         message = (
-            f"{app_name} app requested unsupported extra user role on {endpoint_name} endpoint"
+            f"{app_name} app requested unsupported extra user role on "
+            f"{endpoint_name} endpoint"
         )
         logger.warning(message)
         super().__init__(ops.BlockedStatus(message))
+
+
+class _InvalidDatabaseName(status_exception.StatusException):
+    """Application charm requested an invalid database name"""
+
+    def __init__(self, *, app_name: str, endpoint_name: str, exception_msg: str) -> None:
+        message = (
+            f"{app_name} app requested an invalid database name on "
+            f"{endpoint_name} endpoint: {exception_msg}"
+        )
+        logger.warning(message)
+        super().__init__(ops.BlockedStatus(exception_msg))
 
 
 class _Relation:
@@ -79,9 +92,19 @@ class _RelationThatRequestedUser(_Relation):
         if isinstance(event, ops.RelationBrokenEvent) and event.relation.id == self._id:
             raise _RelationBreaking
         self._database: str = self._databag["database"]
+        self._app_name: str = relation.app.name
+        self._endpoint_name: str = relation.name
+        database_dba_role = f"{mysql_shell.ROLE_DBA_PREFIX}_{self._database}"
+        if len(database_dba_role) >= mysql_shell.ROLE_MAX_LENGTH:
+            raise _InvalidDatabaseName(
+                app_name=self._app_name,
+                endpoint_name=self._endpoint_name,
+                exception_msg="Database DBA role longer than 32 characters",
+            )
         if self._databag.get("extra-user-roles"):
             raise _UnsupportedExtraUserRole(
-                app_name=relation.app.name, endpoint_name=relation.name
+                app_name=self._app_name,
+                endpoint_name=self._endpoint_name,
             )
 
     def _set_databag(
@@ -121,10 +144,10 @@ class _RelationThatRequestedUser(_Relation):
         shell.delete_user(username, must_exist=False)
         logger.debug("Deleted user if exists before creating user")
 
-        password = shell.create_application_database_and_user(
-            username=username, database=self._database
+        password = shell.create_application_database(
+            database=self._database,
+            username=username,
         )
-
         self._set_databag(
             username=username,
             password=password,

--- a/kubernetes/tests/unit/conftest.py
+++ b/kubernetes/tests/unit/conftest.py
@@ -47,6 +47,7 @@ def patch(monkeypatch):
     )
     monkeypatch.setattr("common.workload.RunningWorkload._router_username", "")
     monkeypatch.setattr("common.mysql_shell.Shell._run_code", lambda *args, **kwargs: None)
+    monkeypatch.setattr("common.mysql_shell.Shell._get_mysql_roles", lambda *args, **kwargs: set())
     monkeypatch.setattr(
         "common.mysql_shell.Shell.get_mysql_router_user_for_unit", lambda *args, **kwargs: None
     )

--- a/kubernetes/tests/unit/conftest.py
+++ b/kubernetes/tests/unit/conftest.py
@@ -47,6 +47,9 @@ def patch(monkeypatch):
     )
     monkeypatch.setattr("common.workload.RunningWorkload._router_username", "")
     monkeypatch.setattr("common.mysql_shell.Shell._run_code", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        "common.mysql_shell.Shell._get_mysql_databases", lambda *args, **kwargs: set()
+    )
     monkeypatch.setattr("common.mysql_shell.Shell._get_mysql_roles", lambda *args, **kwargs: set())
     monkeypatch.setattr(
         "common.mysql_shell.Shell.get_mysql_router_user_for_unit", lambda *args, **kwargs: None

--- a/machines/src/relations/deprecated_shared_db_database_provides.py
+++ b/machines/src/relations/deprecated_shared_db_database_provides.py
@@ -147,8 +147,9 @@ class _RelationThatRequestedUser(_UnitThatNeedsUser):
         shell.delete_user(self._username, must_exist=False)
         logger.debug("Deleted user if exists before creating user")
 
-        password = shell.create_application_database_and_user(
-            username=self._username, database=self._database
+        password = shell.create_application_database(
+            database=self._database,
+            username=self._username,
         )
         self._peer_app_databag[self.peer_databag_password_key] = password
         self.set_databag(password=password)

--- a/machines/tests/unit/conftest.py
+++ b/machines/tests/unit/conftest.py
@@ -60,6 +60,9 @@ def patch(monkeypatch):
     )
     monkeypatch.setattr("common.workload.RunningWorkload._router_username", "")
     monkeypatch.setattr("common.mysql_shell.Shell._run_code", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        "common.mysql_shell.Shell._get_mysql_databases", lambda *args, **kwargs: set()
+    )
     monkeypatch.setattr("common.mysql_shell.Shell._get_mysql_roles", lambda *args, **kwargs: set())
     monkeypatch.setattr(
         "common.mysql_shell.Shell.get_mysql_router_user_for_unit", lambda *args, **kwargs: None

--- a/machines/tests/unit/conftest.py
+++ b/machines/tests/unit/conftest.py
@@ -60,6 +60,7 @@ def patch(monkeypatch):
     )
     monkeypatch.setattr("common.workload.RunningWorkload._router_username", "")
     monkeypatch.setattr("common.mysql_shell.Shell._run_code", lambda *args, **kwargs: None)
+    monkeypatch.setattr("common.mysql_shell.Shell._get_mysql_roles", lambda *args, **kwargs: set())
     monkeypatch.setattr(
         "common.mysql_shell.Shell.get_mysql_router_user_for_unit", lambda *args, **kwargs: None
     )


### PR DESCRIPTION
This PR supports the set of predefined roles proposed in [this specification](https://docs.google.com/document/d/1U1tAWx9a7eb0HvdiS7lnSJS8oHqcl6F9PnAoRdcMjmc/edit?tab=t.0).

Contents have been ported from the MySQL Router VM and K8s approved PRs. However, clauses to create a DBA role for each created databases have been added (see [code](https://github.com/canonical/mysql-router-operators/blob/c0ce9031d886f70894cbc168efc1082d6e7e95b5/common/common/mysql_shell/__init__.py#L159-L165)), which is something that got added late into the spec review process.
