### PR TITLE
[DPE-7796] Define Terraform modules

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,8 @@ jobs:
         uses: actions/checkout@v5
       - name: Set up Terraform CLI
         uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
       - name: Install tox & poetry
         run: |
           pipx install tox

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,13 +34,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+      - name: Set up Terraform CLI
+        uses: hashicorp/setup-terraform@v3
       - name: Install tox & poetry
         run: |
           pipx install tox
           pipx install poetry
       - name: Run linters
         working-directory: ${{ matrix.path }}
-        run: tox run -e lint
+        run: |
+          tox run -e lint
+          tox run -e lint-terraform
 
   unit-test:
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,10 +34,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-      - name: Set up Terraform CLI
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_wrapper: false
+      - name: Install terraform
+        run: |
+          sudo snap install terraform --classic
       - name: Install tox & poetry
         run: |
           pipx install tox

--- a/kubernetes/.gitignore
+++ b/kubernetes/.gitignore
@@ -8,3 +8,6 @@ build/
 .coverage
 __pycache__/
 *.py[cod]
+
+.terraform
+.terraform.lock.hcl

--- a/kubernetes/terraform/main.tf
+++ b/kubernetes/terraform/main.tf
@@ -1,0 +1,15 @@
+resource "juju_application" "mysql_router" {
+  name  = var.app_name
+  model = var.model_name
+
+  charm {
+    name     = "mysql-router-k8s"
+    base     = var.base
+    channel  = var.channel
+    revision = var.revision
+  }
+
+  config      = var.config
+  constraints = var.constraints
+  units       = var.units
+}

--- a/kubernetes/terraform/outputs.tf
+++ b/kubernetes/terraform/outputs.tf
@@ -7,15 +7,15 @@ output "provides" {
   description = "Map of all the provided endpoints"
   value = {
     database          = "database"
-    grafana-dashboard = "grafana-dashboard"
-    metrics-endpoint  = "metrics-endpoint"
+    grafana_dashboard = "grafana-dashboard"
+    metrics_endpoint  = "metrics-endpoint"
   }
 }
 
 output "requires" {
   description = "Map of all the required endpoints"
   value = {
-    backend-database = "backend-database"
+    backend_database = "backend-database"
     certificates     = "certificates"
     logging          = "logging"
     tracing          = "tracing"

--- a/kubernetes/terraform/outputs.tf
+++ b/kubernetes/terraform/outputs.tf
@@ -1,0 +1,23 @@
+output "app_name" {
+  description = "Name of the MySQL Router K8s application"
+  value       = juju_application.mysql_router.name
+}
+
+output "provides" {
+  description = "Map of all the provided endpoints"
+  value = {
+    database          = "database"
+    grafana-dashboard = "grafana-dashboard"
+    metrics-endpoint  = "metrics-endpoint"
+  }
+}
+
+output "requires" {
+  description = "Map of all the required endpoints"
+  value = {
+    backend-database = "backend-database"
+    certificates     = "certificates"
+    logging          = "logging"
+    tracing          = "tracing"
+  }
+}

--- a/kubernetes/terraform/variables.tf
+++ b/kubernetes/terraform/variables.tf
@@ -1,0 +1,46 @@
+variable "model_name" {
+  description = "Name of the juju model to deploy to"
+  type        = string
+}
+
+variable "app_name" {
+  description = "Name of the juju application"
+  type        = string
+  default     = "mysql-router"
+}
+
+variable "base" {
+  description = "Application base"
+  type        = string
+  default     = "ubuntu@22.04"
+}
+
+variable "config" {
+  description = "Application configuration. Details at https://charmhub.io/mysql-router-k8s/configurations"
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "Juju constraints for the application"
+  type        = string
+  default     = "arch=amd64"
+}
+
+variable "channel" {
+  description = "Charm channel to deploy from"
+  type        = string
+  default     = "8.0/stable"
+}
+
+variable "revision" {
+  description = "Charm revision to deploy"
+  type        = number
+  default     = null
+}
+
+variable "units" {
+  description = "Number of units to deploy"
+  type        = number
+  default     = 1
+}

--- a/kubernetes/terraform/variables.tf
+++ b/kubernetes/terraform/variables.tf
@@ -6,7 +6,7 @@ variable "model_name" {
 variable "app_name" {
   description = "Name of the juju application"
   type        = string
-  default     = "mysql-router"
+  default     = "mysql-router-k8s"
 }
 
 variable "base" {

--- a/kubernetes/terraform/versions.tf
+++ b/kubernetes/terraform/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.20.0"
+      version = ">= 0.20.0, < 1.0.0"
     }
   }
 }

--- a/kubernetes/terraform/versions.tf
+++ b/kubernetes/terraform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.6"
+
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.20.0"
+    }
+  }
+}

--- a/kubernetes/tox.ini
+++ b/kubernetes/tox.ini
@@ -9,6 +9,7 @@ env_list = lint, unit
 src_path = "{tox_root}/src"
 tests_path = "{tox_root}/tests"
 scripts_path = "{tox_root}/scripts"
+terraform_path = "{tox_root}/terraform"
 all_path = {[vars]src_path} {[vars]tests_path} {[vars]scripts_path}
 
 [testenv]
@@ -41,9 +42,9 @@ commands =
 [testenv:lint-terraform]
 description = Check code against Terraform style standards
 commands =
-    terraform fmt -check -diff -recursive ./terraform
-    terraform -chdir=./terraform init -backend=false
-    terraform -chdir=./terraform validate
+    terraform fmt -check -diff -recursive {[vars]terraform_path}
+    terraform -chdir={[vars]terraform_path} init -backend=false
+    terraform -chdir={[vars]terraform_path} validate
 
 [testenv:unit]
 description = Run unit tests

--- a/kubernetes/tox.ini
+++ b/kubernetes/tox.ini
@@ -17,6 +17,7 @@ set_env =
     PY_COLORS = 1
 allowlist_externals =
     poetry
+    terraform
 
 [testenv:format]
 description = Apply coding style standards to code
@@ -36,6 +37,13 @@ commands =
     poetry run codespell {[vars]all_path}
     poetry run ruff check {[vars]all_path}
     poetry run ruff format --check --diff {[vars]all_path}
+
+[testenv:lint-terraform]
+description = Check code against Terraform style standards
+commands =
+    terraform fmt -check -diff -recursive ./terraform
+    terraform -chdir=./terraform init -backend=false
+    terraform -chdir=./terraform validate
 
 [testenv:unit]
 description = Run unit tests

--- a/machines/.gitignore
+++ b/machines/.gitignore
@@ -9,3 +9,6 @@ build/
 coverage.xml
 __pycache__/
 *.py[cod]
+
+.terraform
+.terraform.lock.hcl

--- a/machines/terraform/main.tf
+++ b/machines/terraform/main.tf
@@ -1,0 +1,15 @@
+resource "juju_application" "mysql_router" {
+  name  = var.app_name
+  model = var.model_name
+
+  charm {
+    name     = "mysql-router"
+    base     = var.base
+    channel  = var.channel
+    revision = var.revision
+  }
+
+  config      = var.config
+  constraints = var.constraints
+  units       = var.units
+}

--- a/machines/terraform/outputs.tf
+++ b/machines/terraform/outputs.tf
@@ -7,14 +7,14 @@ output "provides" {
   description = "Map of all the provided endpoints"
   value = {
     database  = "database"
-    cos-agent = "cos-agent"
+    cos_agent = "cos-agent"
   }
 }
 
 output "requires" {
   description = "Map of all the required endpoints"
   value = {
-    backend-database = "backend-database"
+    backend_database = "backend-database"
     certificates     = "certificates"
     tracing          = "tracing"
   }

--- a/machines/terraform/outputs.tf
+++ b/machines/terraform/outputs.tf
@@ -1,0 +1,21 @@
+output "app_name" {
+  description = "Name of the MySQL Router VM application"
+  value       = juju_application.mysql_router.name
+}
+
+output "provides" {
+  description = "Map of all the provided endpoints"
+  value = {
+    database  = "database"
+    cos-agent = "cos-agent"
+  }
+}
+
+output "requires" {
+  description = "Map of all the required endpoints"
+  value = {
+    backend-database = "backend-database"
+    certificates     = "certificates"
+    tracing          = "tracing"
+  }
+}

--- a/machines/terraform/variables.tf
+++ b/machines/terraform/variables.tf
@@ -1,0 +1,46 @@
+variable "model_name" {
+  description = "Name of the juju model to deploy to"
+  type        = string
+}
+
+variable "app_name" {
+  description = "Name of the juju application"
+  type        = string
+  default     = "mysql-router"
+}
+
+variable "base" {
+  description = "Application base"
+  type        = string
+  default     = "ubuntu@22.04"
+}
+
+variable "config" {
+  description = "Application configuration. Details at https://charmhub.io/mysql-router/configurations"
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "Juju constraints for the application"
+  type        = string
+  default     = "arch=amd64"
+}
+
+variable "channel" {
+  description = "Charm channel to deploy from"
+  type        = string
+  default     = "dpe/edge"
+}
+
+variable "revision" {
+  description = "Charm revision to deploy"
+  type        = number
+  default     = null
+}
+
+variable "units" {
+  description = "Number of units to deploy"
+  type        = number
+  default     = 1
+}

--- a/machines/terraform/variables.tf
+++ b/machines/terraform/variables.tf
@@ -30,7 +30,7 @@ variable "constraints" {
 variable "channel" {
   description = "Charm channel to deploy from"
   type        = string
-  default     = "dpe/edge"
+  default     = "dpe/candidate"
 }
 
 variable "revision" {

--- a/machines/terraform/versions.tf
+++ b/machines/terraform/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.20.0"
+      version = ">= 0.20.0, < 1.0.0"
     }
   }
 }

--- a/machines/terraform/versions.tf
+++ b/machines/terraform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.6"
+
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.20.0"
+    }
+  }
+}

--- a/machines/tox.ini
+++ b/machines/tox.ini
@@ -8,6 +8,7 @@ env_list = lint, unit
 [vars]
 src_path = "{tox_root}/src"
 tests_path = "{tox_root}/tests"
+terraform_path = "{tox_root}/terraform"
 all_path = {[vars]src_path} {[vars]tests_path}
 
 [testenv]
@@ -40,9 +41,9 @@ commands =
 [testenv:lint-terraform]
 description = Check code against Terraform style standards
 commands =
-    terraform fmt -check -diff -recursive ./terraform
-    terraform -chdir=./terraform init -backend=false
-    terraform -chdir=./terraform validate
+    terraform fmt -check -diff -recursive {[vars]terraform_path}
+    terraform -chdir={[vars]terraform_path} init -backend=false
+    terraform -chdir={[vars]terraform_path} validate
 
 [testenv:unit]
 description = Run unit tests

--- a/machines/tox.ini
+++ b/machines/tox.ini
@@ -16,6 +16,7 @@ set_env =
     PY_COLORS = 1
 allowlist_externals =
     poetry
+    terraform
 
 [testenv:format]
 description = Apply coding style standards to code
@@ -35,6 +36,13 @@ commands =
     poetry run codespell {[vars]all_path}
     poetry run ruff check {[vars]all_path}
     poetry run ruff format --check --diff {[vars]all_path}
+
+[testenv:lint-terraform]
+description = Check code against Terraform style standards
+commands =
+    terraform fmt -check -diff -recursive ./terraform
+    terraform -chdir=./terraform init -backend=false
+    terraform -chdir=./terraform validate
 
 [testenv:unit]
 description = Run unit tests


### PR DESCRIPTION
This PR defines the Terraform modules of both MySQL Router VM & K8s substrates, following the[ CC006 specification](https://docs.google.com/document/d/1EG71A2pJ244PQRaGVzGj7Mx2B_bzE4U_OSqx4eeVI1E/edit?tab=t.0), which outlines how to organize Terrraform variables and outputs at the _charm_ level.

From the list of optional input variables:
- [x] base
- [ ] expose
- [ ] resources
- [ ] machines
- [ ] endpoint_bindings 
- [ ] storage 