### PR TITLE
[DPE-8488] Bump TF juju provider to >= 1.0.0

### DIFF
--- a/kubernetes/terraform/main.tf
+++ b/kubernetes/terraform/main.tf
@@ -1,6 +1,6 @@
 resource "juju_application" "mysql_router" {
-  name  = var.app_name
-  model = var.model_name
+  model_uuid = var.model
+  name       = var.app_name
 
   charm {
     name     = "mysql-router-k8s"

--- a/kubernetes/terraform/variables.tf
+++ b/kubernetes/terraform/variables.tf
@@ -24,7 +24,7 @@ variable "config" {
 variable "constraints" {
   description = "Juju constraints for the application"
   type        = string
-  default     = "arch=amd64"
+  default     = null
 }
 
 variable "channel" {

--- a/kubernetes/terraform/variables.tf
+++ b/kubernetes/terraform/variables.tf
@@ -1,5 +1,5 @@
-variable "model_name" {
-  description = "Name of the juju model to deploy to"
+variable "model" {
+  description = "UUID of the juju model to deploy to"
   type        = string
 }
 

--- a/kubernetes/terraform/versions.tf
+++ b/kubernetes/terraform/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.20.0, < 1.0.0"
+      version = ">= 1.0.0"
     }
   }
 }

--- a/machines/terraform/main.tf
+++ b/machines/terraform/main.tf
@@ -1,6 +1,6 @@
 resource "juju_application" "mysql_router" {
-  name  = var.app_name
-  model = var.model_name
+  model_uuid = var.model
+  name       = var.app_name
 
   charm {
     name     = "mysql-router"

--- a/machines/terraform/variables.tf
+++ b/machines/terraform/variables.tf
@@ -24,7 +24,7 @@ variable "config" {
 variable "constraints" {
   description = "Juju constraints for the application"
   type        = string
-  default     = "arch=amd64"
+  default     = null
 }
 
 variable "channel" {

--- a/machines/terraform/variables.tf
+++ b/machines/terraform/variables.tf
@@ -1,5 +1,5 @@
-variable "model_name" {
-  description = "Name of the juju model to deploy to"
+variable "model" {
+  description = "UUID of the juju model to deploy to"
   type        = string
 }
 

--- a/machines/terraform/versions.tf
+++ b/machines/terraform/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.20.0, < 1.0.0"
+      version = ">= 1.0.0"
     }
   }
 }


### PR DESCRIPTION
This PR bumps the Juju Terraform provider to version `1.0.0` or above (see [release notes](https://discourse.charmhub.io/t/the-juju-terraform-provider-1-0-0/19107)). We need to update:

- The TF definitions: to avoid using the `model_name` variable name (it is not a name anymore).

---

To be merged on October 27th.