### PR TITLE
[DPE-8600] Point certificates charm to 1/stable

### DIFF
--- a/kubernetes/tests/integration/test_exporter_with_tls.py
+++ b/kubernetes/tests/integration/test_exporter_with_tls.py
@@ -34,18 +34,14 @@ RETRY_TIMEOUT = 3 * 60
 
 if juju_.is_3_or_higher:
     tls_app_name = "self-signed-certificates"
-    if architecture.architecture == "arm64":
-        tls_channel = "latest/edge"
-    else:
-        tls_channel = "latest/stable"
+    tls_channel = "1/stable"
     tls_config = {"ca-common-name": "Test CA"}
+    tls_base = "ubuntu@24.04"
 else:
     tls_app_name = "tls-certificates-operator"
-    if architecture.architecture == "arm64":
-        tls_channel = "legacy/edge"
-    else:
-        tls_channel = "legacy/stable"
+    tls_channel = "legacy/edge" if architecture.architecture == "arm64" else "legacy/stable"
     tls_config = {"generate-self-signed-certificates": "true", "ca-common-name": "Test CA"}
+    tls_base = "ubuntu@22.04"
 
 
 # TODO: remove after https://github.com/canonical/grafana-agent-k8s-operator/issues/309 fixed
@@ -138,7 +134,7 @@ async def test_exporter_endpoint(ops_test: OpsTest, charm) -> None:
         application_name=tls_app_name,
         channel=tls_channel,
         config=tls_config,
-        base="ubuntu@22.04",
+        base=tls_base,
     )
 
     await ops_test.model.wait_for_idle([tls_app_name], status="active", timeout=SLOW_TIMEOUT)

--- a/kubernetes/tests/integration/test_expose_external.py
+++ b/kubernetes/tests/integration/test_expose_external.py
@@ -36,18 +36,14 @@ TEST_DATABASE_NAME = "testdatabase"
 TLS_SETUP_SLEEP_TIME = 30
 if juju_.is_3_or_higher:
     TLS_APP_NAME = "self-signed-certificates"
-    if architecture.architecture == "arm64":
-        TLS_CHANNEL = "latest/edge"
-    else:
-        TLS_CHANNEL = "latest/stable"
+    TLS_CHANNEL = "1/stable"
     TLS_CONFIG = {"ca-common-name": "Test CA"}
+    TLS_BASE = "ubuntu@24.04"
 else:
     TLS_APP_NAME = "tls-certificates-operator"
-    if architecture.architecture == "arm64":
-        TLS_CHANNEL = "legacy/edge"
-    else:
-        TLS_CHANNEL = "legacy/stable"
+    TLS_CHANNEL = "legacy/edge" if architecture.architecture == "arm64" else "legacy/stable"
     TLS_CONFIG = {"generate-self-signed-certificates": "true", "ca-common-name": "Test CA"}
+    TLS_BASE = "ubuntu@22.04"
 
 
 async def confirm_cluster_ip_endpoints(ops_test: OpsTest) -> None:
@@ -197,7 +193,7 @@ async def test_expose_external_with_tls(ops_test: OpsTest) -> None:
         TLS_APP_NAME,
         channel=TLS_CHANNEL,
         config=TLS_CONFIG,
-        base="ubuntu@22.04",
+        base=TLS_BASE,
     )
     async with ops_test.fast_forward("60s"):
         await ops_test.model.wait_for_idle(

--- a/kubernetes/tests/integration/test_tls.py
+++ b/kubernetes/tests/integration/test_tls.py
@@ -30,18 +30,14 @@ RETRY_TIMEOUT = 2 * 60
 
 if juju_.is_3_or_higher:
     tls_app_name = "self-signed-certificates"
-    if architecture.architecture == "arm64":
-        tls_channel = "latest/edge"
-    else:
-        tls_channel = "latest/stable"
+    tls_channel = "1/stable"
     tls_config = {"ca-common-name": "Test CA"}
+    tls_base = "ubuntu@24.04"
 else:
     tls_app_name = "tls-certificates-operator"
-    if architecture.architecture == "arm64":
-        tls_channel = "legacy/edge"
-    else:
-        tls_channel = "legacy/stable"
+    tls_channel = "legacy/edge" if architecture.architecture == "arm64" else "legacy/stable"
     tls_config = {"generate-self-signed-certificates": "true", "ca-common-name": "Test CA"}
+    tls_base = "ubuntu@22.04"
 
 
 @pytest.mark.abort_on_fail
@@ -79,7 +75,7 @@ async def test_deploy_and_relate(ops_test: OpsTest, charm) -> None:
                 application_name=tls_app_name,
                 channel=tls_channel,
                 config=tls_config,
-                base="ubuntu@22.04",
+                base=tls_base,
             ),
             ops_test.model.deploy(
                 TEST_APP_NAME,

--- a/machines/tests/integration/test_data_integrator.py
+++ b/machines/tests/integration/test_data_integrator.py
@@ -29,12 +29,14 @@ TEST_TABLE = "testtable"
 
 if juju_.is_3_or_higher:
     tls_app_name = "self-signed-certificates"
-    tls_channel = "latest/edge" if architecture.architecture == "arm64" else "latest/stable"
+    tls_channel = "1/stable"
     tls_config = {"ca-common-name": "Test CA"}
+    tls_series = "noble"
 else:
     tls_app_name = "tls-certificates-operator"
     tls_channel = "legacy/edge" if architecture.architecture == "arm64" else "legacy/stable"
     tls_config = {"generate-self-signed-certificates": "true", "ca-common-name": "Test CA"}
+    tls_series = "jammy"
 
 
 @pytest.mark.abort_on_fail
@@ -59,7 +61,11 @@ async def test_external_connectivity_with_data_integrator(
                 series=series,
             ),
             ops_test.model.deploy(
-                tls_app_name, application_name=tls_app_name, channel=tls_channel, config=tls_config
+                tls_app_name,
+                application_name=tls_app_name,
+                channel=tls_channel,
+                config=tls_config,
+                series=tls_series,
             ),
             ops_test.model.deploy(
                 DATA_INTEGRATOR_APP_NAME,

--- a/machines/tests/integration/test_exporter_with_tls.py
+++ b/machines/tests/integration/test_exporter_with_tls.py
@@ -29,12 +29,14 @@ RETRY_TIMEOUT = 3 * 60
 
 if juju_.is_3_or_higher:
     tls_app_name = "self-signed-certificates"
-    tls_channel = "latest/edge" if architecture.architecture == "arm64" else "latest/stable"
+    tls_channel = "1/stable"
     tls_config = {"ca-common-name": "Test CA"}
+    tls_series = "noble"
 else:
     tls_app_name = "tls-certificates-operator"
     tls_channel = "legacy/edge" if architecture.architecture == "arm64" else "legacy/stable"
     tls_config = {"generate-self-signed-certificates": "true", "ca-common-name": "Test CA"}
+    tls_series = "jammy"
 
 
 @pytest.mark.abort_on_fail
@@ -138,7 +140,7 @@ async def test_exporter_endpoint(ops_test: OpsTest, charm, series) -> None:
         application_name=tls_app_name,
         channel=tls_channel,
         config=tls_config,
-        series="jammy",
+        series=tls_series,
     )
     await ops_test.model.wait_for_idle([tls_app_name], status="active", timeout=SLOW_TIMEOUT)
 

--- a/machines/tests/integration/test_hacluster.py
+++ b/machines/tests/integration/test_hacluster.py
@@ -34,12 +34,14 @@ TEST_DATABASE = "testdatabase"
 
 if juju_.is_3_or_higher:
     tls_app_name = "self-signed-certificates"
-    tls_channel = "latest/edge" if architecture.architecture == "arm64" else "latest/stable"
+    tls_channel = "1/stable"
     tls_config = {"ca-common-name": "Test CA"}
+    tls_series = "noble"
 else:
     tls_app_name = "tls-certificates-operator"
     tls_channel = "legacy/edge" if architecture.architecture == "arm64" else "legacy/stable"
     tls_config = {"generate-self-signed-certificates": "true", "ca-common-name": "Test CA"}
+    tls_series = "jammy"
 
 vip = None
 
@@ -266,6 +268,7 @@ async def test_tls_along_with_ha_cluster(ops_test: OpsTest, series) -> None:
             application_name=tls_app_name,
             channel=tls_channel,
             config=tls_config,
+            series=tls_series,
         )
 
     logger.info("Ensure auto-generated TLS cert before relation with TLS")

--- a/machines/tests/integration/test_tls.py
+++ b/machines/tests/integration/test_tls.py
@@ -26,12 +26,14 @@ RETRY_TIMEOUT = 60
 
 if juju_.is_3_or_higher:
     tls_app_name = "self-signed-certificates"
-    tls_channel = "latest/edge" if architecture.architecture == "arm64" else "latest/stable"
+    tls_channel = "1/stable"
     tls_config = {"ca-common-name": "Test CA"}
+    tls_series = "noble"
 else:
     tls_app_name = "tls-certificates-operator"
     tls_channel = "legacy/edge" if architecture.architecture == "arm64" else "legacy/stable"
     tls_config = {"generate-self-signed-certificates": "true", "ca-common-name": "Test CA"}
+    tls_series = "jammy"
 
 
 @pytest.mark.abort_on_fail
@@ -61,7 +63,7 @@ async def test_build_deploy_and_relate(ops_test: OpsTest, charm, series) -> None
                 application_name=tls_app_name,
                 channel=tls_channel,
                 config=tls_config,
-                series="jammy",
+                series=tls_series,
             ),
             ops_test.model.deploy(
                 TEST_APP_NAME,


### PR DESCRIPTION
This PR updates the integration tests by pointing `self-signed-certificates` to the  `1/stable` channel.

Depends on PRs https://github.com/canonical/mysql-router-operators/pull/70 & https://github.com/canonical/mysql-router-operators/pull/71.
