### PR TITLE
[MISC] Replace charmcraft-test by spread

### DIFF
--- a/.github/workflows/integration_test_charm.yaml
+++ b/.github/workflows/integration_test_charm.yaml
@@ -24,6 +24,8 @@ jobs:
       - name: Set up environment
         run: |
           sudo snap install charmcraft --classic
+          sudo snap install go --classic
+          go install github.com/snapcore/spread/cmd/spread@latest
           pipx install tox poetry
       - name: Collect spread jobs
         id: collect-jobs
@@ -32,11 +34,15 @@ jobs:
         run: |
           import json
           import os
+          import pathlib
           import subprocess
 
           spread_jobs = (
               subprocess.run(
-                  ["charmcraft", "test", "--list", "github-ci"], capture_output=True, check=True, text=True
+                  [pathlib.Path.home() / "go/bin/spread", "-list", "github-ci"],
+                  capture_output=True,
+                  check=True,
+                  text=True,
               )
               .stdout.strip()
               .split("\n")
@@ -106,10 +112,8 @@ jobs:
         uses: actions/checkout@v5
       - name: Set up environment
         timeout-minutes: 5
-        run: sudo snap install charmcraft --classic
-      # TODO: remove when https://github.com/canonical/charmcraft/issues/2105 and
-      # https://github.com/canonical/charmcraft/issues/2130 fixed
-      - run: |
+        run: |
+          sudo snap install charmcraft --classic
           sudo snap install go --classic
           go install github.com/snapcore/spread/cmd/spread@latest
       - name: Download packed charm(s)
@@ -122,9 +126,6 @@ jobs:
         timeout-minutes: 180
         id: spread
         working-directory: ${{ inputs.path-to-charm-directory }}
-        # TODO: replace with `charmcraft test` when
-        # https://github.com/canonical/charmcraft/issues/2105 and
-        # https://github.com/canonical/charmcraft/issues/2130 fixed
         run: ~/go/bin/spread -vv -artifacts=artifacts '${{ matrix.job.spread_job }}'
         env:
           UBUNTU_PRO_TOKEN: ${{ secrets.UBUNTU_PRO_TOKEN }}


### PR DESCRIPTION
This PR replaces `charmcraft test` by `spread` when it comes to collecting the tests on CI.

This fixes compatibility with `charmcraft` 4.0.1+