### PR TITLE
[MISC] Downgrade ARM runner to 22.04

### DIFF
--- a/machines/spread.yaml
+++ b/machines/spread.yaml
@@ -76,10 +76,9 @@ backends:
     allocate: |
       sudo tee /etc/ssh/sshd_config.d/10-spread-github-ci.conf << 'EOF'
       PasswordAuthentication yes
-      PermitEmptyPasswords yes
       EOF
 
-      sudo passwd --delete "$USER"
+      echo "runner:$SPREAD_PASSWORD" | sudo chpasswd
 
       ADDRESS localhost
     # HACK: spread does not pass environment variables set on runner

--- a/machines/spread.yaml
+++ b/machines/spread.yaml
@@ -93,7 +93,9 @@ backends:
     systems:
       - ubuntu-24.04:
           username: runner
-      - ubuntu-24.04-arm:
+      # TODO: Revert to ubuntu-24.04-arm once Kernel 6.14 issue is solved
+      # https://gitlab.com/apparmor/apparmor/-/issues/571
+      - ubuntu-22.04-arm:
           username: runner
           variants:
             - -juju29


### PR DESCRIPTION
This PR is the counterpart to this [PostgreSQL VM PR](https://github.com/canonical/postgresql-operator/pull/1303), downgrading the runner to Ubuntu 22.04 due to an AppArmor bug.

Depends on https://github.com/canonical/mysql-router-operators/pull/70.
