### PR TITLE
fix: escape role_name on creation

### DIFF
--- a/common/common/mysql_shell/__init__.py
+++ b/common/common/mysql_shell/__init__.py
@@ -179,8 +179,8 @@ class Shell:
         statements = [
             f"CREATE ROLE `{role_name}`",
             f"CREATE DATABASE `{database}`",
-            f"GRANT SELECT, INSERT, DELETE, UPDATE, EXECUTE ON `{database}`.* TO {role_name}",
-            f"GRANT ALTER, ALTER ROUTINE, CREATE, CREATE ROUTINE, CREATE VIEW, DROP, INDEX, LOCK TABLES, REFERENCES, TRIGGER ON `{database}`.* TO {role_name}",
+            f"GRANT SELECT, INSERT, DELETE, UPDATE, EXECUTE ON `{database}`.* TO `{role_name}`",
+            f"GRANT ALTER, ALTER ROUTINE, CREATE, CREATE ROUTINE, CREATE VIEW, DROP, INDEX, LOCK TABLES, REFERENCES, TRIGGER ON `{database}`.* TO `{role_name}`",
         ]
 
         mysql_roles = self._get_mysql_roles("charmed_%")


### PR DESCRIPTION
## Issue

Role names with hyphen brakes role creation. Issue detected on [sysbench tests](https://github.com/canonical/sysbench-operator/actions/runs/19689287178/job/56403832900#step:32:1442)

## Solution

Escape name creation. Tested locally
