### PR TITLE
[MISC] Refactor K8s tests to use `series`

### DIFF
--- a/kubernetes/tests/integration/conftest.py
+++ b/kubernetes/tests/integration/conftest.py
@@ -13,11 +13,21 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture
-def charm():
+def ubuntu_base():
+    return "ubuntu@22.04"
+
+
+@pytest.fixture
+def series():
+    return "jammy"
+
+
+@pytest.fixture
+def charm(ubuntu_base):
     # Return str instead of pathlib.Path since python-libjuju's model.deploy(), juju deploy, and
     # juju bundle files expect local charms to begin with `./` or `/` to distinguish them from
     # Charmhub charms.
-    return f"./mysql-router-k8s_ubuntu@22.04-{architecture.architecture}.charm"
+    return f"./mysql-router-k8s_{ubuntu_base}-{architecture.architecture}.charm"
 
 
 @pytest.fixture

--- a/kubernetes/tests/integration/test_architecture.py
+++ b/kubernetes/tests/integration/test_architecture.py
@@ -14,7 +14,7 @@ MYSQL_ROUTER_APP_NAME = METADATA["name"]
 
 
 @markers.amd64_only
-async def test_arm_charm_on_amd_host(ops_test: OpsTest) -> None:
+async def test_arm_charm_on_amd_host(ops_test: OpsTest, series) -> None:
     """Tries deploying an arm64 charm on amd64 host."""
     charm = "./mysql-router-k8s_ubuntu@22.04-arm64.charm"
 
@@ -27,7 +27,7 @@ async def test_arm_charm_on_amd_host(ops_test: OpsTest) -> None:
         application_name=MYSQL_ROUTER_APP_NAME,
         num_units=1,
         resources=resources,
-        base="ubuntu@22.04",
+        series=series,
     )
 
     await ops_test.model.wait_for_idle(
@@ -38,7 +38,7 @@ async def test_arm_charm_on_amd_host(ops_test: OpsTest) -> None:
 
 
 @markers.arm64_only
-async def test_amd_charm_on_arm_host(ops_test: OpsTest) -> None:
+async def test_amd_charm_on_arm_host(ops_test: OpsTest, series) -> None:
     """Tries deploying an amd64 charm on arm64 host."""
     charm = "./mysql-router-k8s_ubuntu@22.04-amd64.charm"
 
@@ -51,7 +51,7 @@ async def test_amd_charm_on_arm_host(ops_test: OpsTest) -> None:
         application_name=MYSQL_ROUTER_APP_NAME,
         num_units=1,
         resources=resources,
-        base="ubuntu@22.04",
+        series=series,
     )
 
     await ops_test.model.wait_for_idle(

--- a/kubernetes/tests/integration/test_charm.py
+++ b/kubernetes/tests/integration/test_charm.py
@@ -34,7 +34,7 @@ MODEL_CONFIG = {"logging-config": "<root>=INFO;unit=DEBUG"}
 
 
 @pytest.mark.abort_on_fail
-async def test_database_relation(ops_test: OpsTest, charm):
+async def test_database_relation(ops_test: OpsTest, charm, series):
     """Test the database relation."""
     await ops_test.model.set_config(MODEL_CONFIG)
 
@@ -49,15 +49,15 @@ async def test_database_relation(ops_test: OpsTest, charm):
             channel="8.0/edge",
             application_name=MYSQL_APP_NAME,
             config={"profile": "testing"},
-            base="ubuntu@22.04",
+            series=series,
             num_units=3,
             trust=True,  # Necessary after a6f1f01: Fix/endpoints as k8s services (#142)
         ),
         ops_test.model.deploy(
             charm,
             application_name=MYSQL_ROUTER_APP_NAME,
-            base="ubuntu@22.04",
             resources=mysqlrouter_resources,
+            series=series,
             num_units=1,
             trust=True,
         ),
@@ -65,7 +65,7 @@ async def test_database_relation(ops_test: OpsTest, charm):
             APPLICATION_APP_NAME,
             channel="latest/edge",
             application_name=APPLICATION_APP_NAME,
-            base="ubuntu@22.04",
+            series=series,
             num_units=1,
         ),
     )

--- a/kubernetes/tests/integration/test_exporter.py
+++ b/kubernetes/tests/integration/test_exporter.py
@@ -35,7 +35,7 @@ RETRY_TIMEOUT = 3 * 60
 # TODO: remove after https://github.com/canonical/grafana-agent-k8s-operator/issues/309 fixed
 @markers.amd64_only
 @pytest.mark.abort_on_fail
-async def test_exporter_endpoint(ops_test: OpsTest, charm) -> None:
+async def test_exporter_endpoint(ops_test: OpsTest, charm, series) -> None:
     """Test that exporter endpoint is functional."""
     mysqlrouter_resources = {
         "mysql-router-image": METADATA["resources"]["mysql-router-image"]["upstream-source"]
@@ -49,15 +49,15 @@ async def test_exporter_endpoint(ops_test: OpsTest, charm) -> None:
             channel="8.0/edge",
             application_name=MYSQL_APP_NAME,
             config={"profile": "testing"},
-            base="ubuntu@22.04",
+            series=series,
             num_units=1,
             trust=True,
         ),
         ops_test.model.deploy(
             charm,
             application_name=MYSQL_ROUTER_APP_NAME,
-            base="ubuntu@22.04",
             resources=mysqlrouter_resources,
+            series=series,
             num_units=1,
             trust=True,
         ),
@@ -65,15 +65,15 @@ async def test_exporter_endpoint(ops_test: OpsTest, charm) -> None:
             APPLICATION_APP_NAME,
             channel="latest/edge",
             application_name=APPLICATION_APP_NAME,
-            base="ubuntu@22.04",
+            series=series,
             num_units=1,
         ),
         ops_test.model.deploy(
             GRAFANA_AGENT_APP_NAME,
-            application_name=GRAFANA_AGENT_APP_NAME,
-            num_units=1,
-            base="ubuntu@22.04",
             channel="1/stable",
+            application_name=GRAFANA_AGENT_APP_NAME,
+            series=series,
+            num_units=1,
         ),
     )
 

--- a/kubernetes/tests/integration/test_exporter_with_tls.py
+++ b/kubernetes/tests/integration/test_exporter_with_tls.py
@@ -36,18 +36,18 @@ if juju_.is_3_or_higher:
     tls_app_name = "self-signed-certificates"
     tls_channel = "1/stable"
     tls_config = {"ca-common-name": "Test CA"}
-    tls_base = "ubuntu@24.04"
+    tls_series = "noble"
 else:
     tls_app_name = "tls-certificates-operator"
     tls_channel = "legacy/edge" if architecture.architecture == "arm64" else "legacy/stable"
     tls_config = {"generate-self-signed-certificates": "true", "ca-common-name": "Test CA"}
-    tls_base = "ubuntu@22.04"
+    tls_series = "jammy"
 
 
 # TODO: remove after https://github.com/canonical/grafana-agent-k8s-operator/issues/309 fixed
 @markers.amd64_only
 @pytest.mark.abort_on_fail
-async def test_exporter_endpoint(ops_test: OpsTest, charm) -> None:
+async def test_exporter_endpoint(ops_test: OpsTest, charm, series) -> None:
     """Test that the exporter endpoint works when related with TLS"""
     mysqlrouter_resources = {
         "mysql-router-image": METADATA["resources"]["mysql-router-image"]["upstream-source"]
@@ -61,15 +61,15 @@ async def test_exporter_endpoint(ops_test: OpsTest, charm) -> None:
             channel="8.0/edge",
             application_name=MYSQL_APP_NAME,
             config={"profile": "testing"},
-            base="ubuntu@22.04",
+            series=series,
             num_units=1,
             trust=True,
         ),
         ops_test.model.deploy(
             charm,
             application_name=MYSQL_ROUTER_APP_NAME,
-            base="ubuntu@22.04",
             resources=mysqlrouter_resources,
+            series=series,
             num_units=1,
             trust=True,
         ),
@@ -77,15 +77,15 @@ async def test_exporter_endpoint(ops_test: OpsTest, charm) -> None:
             APPLICATION_APP_NAME,
             channel="latest/edge",
             application_name=APPLICATION_APP_NAME,
-            base="ubuntu@22.04",
+            series=series,
             num_units=1,
         ),
         ops_test.model.deploy(
             GRAFANA_AGENT_APP_NAME,
+            channel="1/stable",
             application_name=GRAFANA_AGENT_APP_NAME,
             num_units=1,
-            base="ubuntu@22.04",
-            channel="1/stable",
+            series=series,
         ),
     )
 
@@ -134,7 +134,7 @@ async def test_exporter_endpoint(ops_test: OpsTest, charm) -> None:
         application_name=tls_app_name,
         channel=tls_channel,
         config=tls_config,
-        base=tls_base,
+        series=tls_series,
     )
 
     await ops_test.model.wait_for_idle([tls_app_name], status="active", timeout=SLOW_TIMEOUT)

--- a/kubernetes/tests/integration/test_expose_external.py
+++ b/kubernetes/tests/integration/test_expose_external.py
@@ -38,12 +38,12 @@ if juju_.is_3_or_higher:
     TLS_APP_NAME = "self-signed-certificates"
     TLS_CHANNEL = "1/stable"
     TLS_CONFIG = {"ca-common-name": "Test CA"}
-    TLS_BASE = "ubuntu@24.04"
+    TLS_SERIES = "noble"
 else:
     TLS_APP_NAME = "tls-certificates-operator"
     TLS_CHANNEL = "legacy/edge" if architecture.architecture == "arm64" else "legacy/stable"
     TLS_CONFIG = {"generate-self-signed-certificates": "true", "ca-common-name": "Test CA"}
-    TLS_BASE = "ubuntu@22.04"
+    TLS_SERIES = "jammy"
 
 
 async def confirm_cluster_ip_endpoints(ops_test: OpsTest) -> None:
@@ -97,7 +97,7 @@ async def confirm_endpoint_connectivity(ops_test: OpsTest) -> None:
 
 
 @pytest.mark.abort_on_fail
-async def test_expose_external(ops_test, charm) -> None:
+async def test_expose_external(ops_test, charm, series) -> None:
     """Test the expose-external config option."""
     await ops_test.model.set_config(MODEL_CONFIG)
 
@@ -112,15 +112,15 @@ async def test_expose_external(ops_test, charm) -> None:
             channel="8.0/edge",
             application_name=MYSQL_APP_NAME,
             config={"profile": "testing"},
-            base="ubuntu@22.04",
+            series=series,
             num_units=1,
             trust=True,
         ),
         ops_test.model.deploy(
             charm,
             application_name=MYSQL_ROUTER_APP_NAME,
-            base="ubuntu@22.04",
             resources=mysql_router_resources,
+            series=series,
             num_units=1,
             trust=True,
         ),
@@ -128,8 +128,8 @@ async def test_expose_external(ops_test, charm) -> None:
             DATA_INTEGRATOR,
             channel="latest/edge",
             application_name=DATA_INTEGRATOR,
-            base="ubuntu@24.04",
             config={"database-name": TEST_DATABASE_NAME},
+            series="noble",
             num_units=1,
         ),
     )
@@ -193,7 +193,7 @@ async def test_expose_external_with_tls(ops_test: OpsTest) -> None:
         TLS_APP_NAME,
         channel=TLS_CHANNEL,
         config=TLS_CONFIG,
-        base=TLS_BASE,
+        series=TLS_SERIES,
     )
     async with ops_test.fast_forward("60s"):
         await ops_test.model.wait_for_idle(

--- a/kubernetes/tests/integration/test_log_rotation.py
+++ b/kubernetes/tests/integration/test_log_rotation.py
@@ -35,7 +35,7 @@ MODEL_CONFIG = {"logging-config": "<root>=INFO;unit=DEBUG"}
 
 
 @pytest.mark.abort_on_fail
-async def test_log_rotation(ops_test: OpsTest, charm):
+async def test_log_rotation(ops_test: OpsTest, charm, series):
     """Test log rotation."""
     await ops_test.model.set_config(MODEL_CONFIG)
 
@@ -50,15 +50,15 @@ async def test_log_rotation(ops_test: OpsTest, charm):
             channel="8.0/edge",
             application_name=MYSQL_APP_NAME,
             config={"profile": "testing"},
-            base="ubuntu@22.04",
+            series=series,
             num_units=3,
             trust=True,  # Necessary after a6f1f01: Fix/endpoints as k8s services (#142)
         ),
         ops_test.model.deploy(
             charm,
             application_name=MYSQL_ROUTER_APP_NAME,
-            base="ubuntu@22.04",
             resources=mysqlrouter_resources,
+            series=series,
             num_units=1,
             trust=True,
         ),
@@ -66,7 +66,7 @@ async def test_log_rotation(ops_test: OpsTest, charm):
             APPLICATION_APP_NAME,
             channel="latest/edge",
             application_name=APPLICATION_APP_NAME,
-            base="ubuntu@22.04",
+            series=series,
             num_units=1,
         ),
     )

--- a/kubernetes/tests/integration/test_tls.py
+++ b/kubernetes/tests/integration/test_tls.py
@@ -32,16 +32,16 @@ if juju_.is_3_or_higher:
     tls_app_name = "self-signed-certificates"
     tls_channel = "1/stable"
     tls_config = {"ca-common-name": "Test CA"}
-    tls_base = "ubuntu@24.04"
+    tls_series = "noble"
 else:
     tls_app_name = "tls-certificates-operator"
     tls_channel = "legacy/edge" if architecture.architecture == "arm64" else "legacy/stable"
     tls_config = {"generate-self-signed-certificates": "true", "ca-common-name": "Test CA"}
-    tls_base = "ubuntu@22.04"
+    tls_series = "jammy"
 
 
 @pytest.mark.abort_on_fail
-async def test_deploy_and_relate(ops_test: OpsTest, charm) -> None:
+async def test_deploy_and_relate(ops_test: OpsTest, charm, series) -> None:
     """Test encryption when backend database is using TLS."""
     mysqlrouter_resources = {
         "mysql-router-image": METADATA["resources"]["mysql-router-image"]["upstream-source"]
@@ -55,7 +55,7 @@ async def test_deploy_and_relate(ops_test: OpsTest, charm) -> None:
             channel="8.0/edge",
             application_name=MYSQL_APP_NAME,
             config={"profile": "testing"},
-            base="ubuntu@22.04",
+            series=series,
             num_units=1,
             trust=True,
         )
@@ -65,8 +65,8 @@ async def test_deploy_and_relate(ops_test: OpsTest, charm) -> None:
             ops_test.model.deploy(
                 charm,
                 application_name=MYSQL_ROUTER_APP_NAME,
-                base="ubuntu@22.04",
                 resources=mysqlrouter_resources,
+                series=series,
                 num_units=1,
                 trust=True,
             ),
@@ -75,13 +75,13 @@ async def test_deploy_and_relate(ops_test: OpsTest, charm) -> None:
                 application_name=tls_app_name,
                 channel=tls_channel,
                 config=tls_config,
-                base=tls_base,
+                series=tls_series,
             ),
             ops_test.model.deploy(
                 TEST_APP_NAME,
                 application_name=TEST_APP_NAME,
                 channel="latest/edge",
-                base="ubuntu@22.04",
+                series=series,
             ),
         )
 

--- a/kubernetes/tests/integration/test_upgrade.py
+++ b/kubernetes/tests/integration/test_upgrade.py
@@ -40,7 +40,7 @@ RESOURCES = {"mysql-router-image": METADATA["resources"]["mysql-router-image"]["
 
 
 @pytest.mark.abort_on_fail
-async def test_deploy_edge(ops_test: OpsTest) -> None:
+async def test_deploy_edge(ops_test: OpsTest, series) -> None:
     """Simple test to ensure that mysql, mysqlrouter and application charms deploy."""
     logger.info("Deploying all applications")
 
@@ -50,26 +50,23 @@ async def test_deploy_edge(ops_test: OpsTest) -> None:
             channel="8.0/edge",
             application_name=MYSQL_APP_NAME,
             config={"profile": "testing"},
-            base="ubuntu@22.04",
+            series=series,
             num_units=1,
             trust=True,  # Necessary after a6f1f01: Fix/endpoints as k8s services (#142)
         ),
-        ops_test.juju(
-            "deploy",
+        ops_test.model.deploy(
             MYSQL_ROUTER_APP_NAME,
-            "-n",
-            3,
-            "--channel",
-            "8.0/edge/test-refresh-v3-8.0.42",  # TODO remove after refresh v3 merged
-            "--trust",
-            "--series",  # For juju 2 compatibility
-            "jammy",
+            channel="8.0/edge",
+            application_name=MYSQL_ROUTER_APP_NAME,
+            series=series,
+            num_units=3,
+            trust=True,  # Necessary after a6f1f01: Fix/endpoints as k8s services (#142)
         ),
         ops_test.model.deploy(
             APPLICATION_APP_NAME,
             channel="latest/edge",
             application_name=APPLICATION_APP_NAME,
-            base="ubuntu@22.04",
+            series=series,
             num_units=1,
         ),
     )

--- a/machines/spread.yaml
+++ b/machines/spread.yaml
@@ -86,7 +86,6 @@ backends:
     # Manually pass specific environment variables
     environment:
       CI: '$(HOST: echo $CI)'
-      CHARM_UBUNTU_BASE: '$(HOST: echo $CHARM_UBUNTU_BASE)'
       UBUNTU_PRO_TOKEN: '$(HOST: echo $UBUNTU_PRO_TOKEN)'
       LANDSCAPE_ACCOUNT_NAME: '$(HOST: echo $LANDSCAPE_ACCOUNT_NAME)'
       LANDSCAPE_REGISTRATION_KEY: '$(HOST: echo $LANDSCAPE_REGISTRATION_KEY)'
@@ -109,7 +108,6 @@ environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
   CONCIERGE_JUJU_CHANNEL/juju36: 3.6/stable
   CONCIERGE_JUJU_CHANNEL/juju29: 2.9/stable
-  CHARM_UBUNTU_BASE/juju36,juju29: 22.04
 prepare: |
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"

--- a/machines/tests/integration/conftest.py
+++ b/machines/tests/integration/conftest.py
@@ -2,7 +2,6 @@
 # See LICENSE file for licensing details.
 
 import logging
-import os
 
 import pytest
 from pytest_operator.plugin import OpsTest
@@ -15,18 +14,12 @@ logger = logging.getLogger(__name__)
 
 @pytest.fixture
 def ubuntu_base():
-    return os.environ["CHARM_UBUNTU_BASE"]
+    return "ubuntu@22.04"
 
 
 @pytest.fixture
-def series(ubuntu_base):
-    """Workaround: python-libjuju does not support deploy with base="ubuntu@20.04"; need to use series"""
-    if ubuntu_base == "20.04":
-        return "focal"
-    elif ubuntu_base == "22.04":
-        return "jammy"
-    else:
-        raise NotImplementedError
+def series():
+    return "jammy"
 
 
 @pytest.fixture
@@ -34,7 +27,7 @@ def charm(ubuntu_base):
     # Return str instead of pathlib.Path since python-libjuju's model.deploy(), juju deploy, and
     # juju bundle files expect local charms to begin with `./` or `/` to distinguish them from
     # Charmhub charms.
-    return f"./mysql-router_ubuntu@{ubuntu_base}-{architecture.architecture}.charm"
+    return f"./mysql-router_{ubuntu_base}-{architecture.architecture}.charm"
 
 
 @pytest.fixture

--- a/machines/tests/integration/test_architecture.py
+++ b/machines/tests/integration/test_architecture.py
@@ -4,7 +4,6 @@
 
 import asyncio
 
-import pytest
 from pytest_operator.plugin import OpsTest
 
 from . import markers
@@ -14,10 +13,8 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 
 
 @markers.amd64_only
-async def test_arm_charm_on_amd_host(ops_test: OpsTest, charm, ubuntu_base, series) -> None:
+async def test_arm_charm_on_amd_host(ops_test: OpsTest, charm, series) -> None:
     """Tries deploying an arm64 charm on amd64 host."""
-    if ubuntu_base == "20.04":
-        pytest.skip("arm64 charm not built for 20.04")
     charm = charm.replace("amd64", "arm64")
 
     await asyncio.gather(

--- a/machines/tests/integration/test_upgrade.py
+++ b/machines/tests/integration/test_upgrade.py
@@ -43,7 +43,7 @@ async def test_deploy_edge(ops_test: OpsTest, series) -> None:
             num_units=1,
             channel="8.0/edge",
             config={"profile": "testing"},
-            series="jammy",
+            series=series,
         ),
         ops_test.model.deploy(
             MYSQL_ROUTER_APP_NAME,

--- a/machines/tox.ini
+++ b/machines/tox.ini
@@ -56,7 +56,6 @@ commands =
 description = Run integration tests
 pass_env =
     CI
-    CHARM_UBUNTU_BASE
     UBUNTU_PRO_TOKEN
     LANDSCAPE_ACCOUNT_NAME
     LANDSCAPE_REGISTRATION_KEY


### PR DESCRIPTION
This PR refactors the K8s integration tests to use `series` instead of the `base` argument. I do not exactly know why, but the version of `ops` that we are using (2.9.0) behaves differently whether one or the other argument is specified. When `base` is used, it seems that the library is not able to detect multi-platform charms

Additionally, I cleaned up the `CHARM_UBUNTU_BASE` env. variable from the VM tests.

---

Unblocks https://github.com/canonical/mysql-router-operators/pull/88.
