### PR TITLE
[MISC] - 8.4 Update metadata links

### DIFF
--- a/kubernetes/metadata.yaml
+++ b/kubernetes/metadata.yaml
@@ -12,7 +12,7 @@ docs: https://discourse.charmhub.io/t/charmed-mysql-router-k8s-documentation/121
 source: https://github.com/canonical/mysql-router-operators
 issues: https://github.com/canonical/mysql-router-operators/issues
 website:
-  - https://ubuntu.com/data/mysql
+  - https://canonical.com/data/mysql
   - https://charmhub.io/mysql-router-k8s
   - https://github.com/canonical/mysql-router-operators
   - https://chat.charmhub.io/charmhub/channels/data-platform

--- a/machines/metadata.yaml
+++ b/machines/metadata.yaml
@@ -12,7 +12,7 @@ docs: https://discourse.charmhub.io/t/charmed-mysql-router-documentation/12131
 source: https://github.com/canonical/mysql-router-operators
 issues: https://github.com/canonical/mysql-router-operators/issues
 website:
-  - https://ubuntu.com/data/mysql
+  - https://canonical.com/data/mysql
   - https://charmhub.io/mysql-router
   - https://github.com/canonical/mysql-router-operators
   - https://chat.charmhub.io/charmhub/channels/data-platform


### PR DESCRIPTION
This PR updates some legacy `metadata.yaml` links.

---

Depends on https://github.com/canonical/mysql-router-operators/pull/86.
