### PR TITLE
[MISC] Remove upgrade test comments

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,6 @@ jobs:
     name: Build charm | ${{ matrix.path }}
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v36.0.1
     with:
-      cache: false  # TODO: cleanup
       path-to-charm-directory: ${{ matrix.path }}
 
   integration-test:

--- a/kubernetes/tests/integration/test_upgrade.py
+++ b/kubernetes/tests/integration/test_upgrade.py
@@ -65,7 +65,7 @@ async def test_deploy_edge(ops_test: OpsTest) -> None:
             APPLICATION_APP_NAME,
             channel="latest/edge",
             application_name=APPLICATION_APP_NAME,
-            base="ubuntu@22.04",
+            base="ubuntu@24.04",
             num_units=1,
         ),
     )

--- a/kubernetes/tests/spread/test_upgrade.py/task.yaml
+++ b/kubernetes/tests/spread/test_upgrade.py/task.yaml
@@ -2,8 +2,6 @@ summary: test_upgrade.py
 environment:
   TEST_MODULE: test_upgrade.py
 execute: |
-  # TODO: Un-comment when we release a 8.4/edge charm
-  # tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
-  exit 0
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/integration/test_upgrade.py
+++ b/machines/tests/integration/test_upgrade.py
@@ -43,13 +43,13 @@ async def test_deploy_edge(ops_test: OpsTest, ubuntu_base) -> None:
             num_units=1,
             channel="8.0/edge",
             config={"profile": "testing"},
-            series="jammy",
+            base="ubuntu@22.04",
         ),
         ops_test.model.deploy(
             MYSQL_ROUTER_APP_NAME,
             application_name=MYSQL_ROUTER_APP_NAME,
             num_units=1,
-            channel="dpe/edge",
+            channel="8.4/edge",
             base=ubuntu_base,
         ),
         ops_test.model.deploy(

--- a/machines/tests/spread/test_upgrade.py/task.yaml
+++ b/machines/tests/spread/test_upgrade.py/task.yaml
@@ -2,8 +2,6 @@ summary: test_upgrade.py
 environment:
   TEST_MODULE: test_upgrade.py
 execute: |
-  # TODO: Un-comment when we release a 8.4/edge charm
-  # tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
-  exit 0
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results


### PR DESCRIPTION
This PR cleanups up a couple of leftovers after branching out the `8.4/edge` branch:

- The CI build cache (thanks to [this PR](https://github.com/canonical/charmcraftcache-hub/pull/776)).
- The CI upgrade tests (once the charm is released to CharmHub).
