### PR TITLE
[MISC] 8.4 - Fix README badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # mysql-router-operators
-[![Charmhub](https://charmhub.io/mysql-router-k8s/badge.svg)](https://charmhub.io/mysql-router-k8s)
+[![Charmhub](https://charmhub.io/mysql-router-k8s/badge.svg?channel=8.4/edge)](https://charmhub.io/mysql-router-k8s)
 [![Charmhub](https://charmhub.io/mysql-router/badge.svg?channel=8.4/edge)](https://charmhub.io/mysql-router)
-[![Release](https://github.com/canonical/mysql-router-operators/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/mysql-router-operators/actions/workflows/release.yaml)
+[![Release](https://github.com/canonical/mysql-router-operators/actions/workflows/release.yaml/badge.svg?branch=8.4/edge)](https://github.com/canonical/mysql-router-operators/actions/workflows/release.yaml)
 [![Tests](https://github.com/canonical/mysql-router-operators/actions/workflows/ci.yaml/badge.svg?branch=8.4/edge)](https://github.com/canonical/mysql-router-operators/actions/workflows/ci.yaml)
 -----------------
 ## Description


### PR DESCRIPTION
This PR fixes the README badge links to make them independent of Charmhub default channel / Git default branch.
