### PR TITLE
[MISC] Set trust attribute to true in TF configs

### DIFF
--- a/kubernetes/terraform/main.tf
+++ b/kubernetes/terraform/main.tf
@@ -1,6 +1,7 @@
 resource "juju_application" "mysql_router" {
   model_uuid = var.model
   name       = var.app_name
+  trust      = true
 
   charm {
     name     = "mysql-router-k8s"


### PR DESCRIPTION
## Issue

The existing TF configs currently don't work since the charms need to be deployed with trust.

For example, on K8s, we get the following `juju status` output: 
```
mysql-router                   blocked      3  mysql-router-k8s      8.4/edge       878  10.86.228.99   no       Run `juju trust mysql-router --scope=cluster`. Needed for in-place refreshes
```

## Solution

Set the `trust` attribute to true in both Terraform config files for the `mysql-router` application.