### PR TITLE
Migrate from refresh v2 charm with downtime

### DIFF
--- a/kubernetes/docs/how-to/h-rollback-minor.md
+++ b/kubernetes/docs/how-to/h-rollback-minor.md
@@ -17,6 +17,13 @@ Although the underlying MySQL Cluster and MySQL Router continue to work, it’s 
 
 To execute a rollback we take the same procedure as the upgrade, the difference being the charm revision to upgrade to. In case of this tutorial example, one would refresh the charm back to revision `88`, the steps being:
 
+[note type="caution"]
+**Warning:** Doing a rollback is only possible between revisions that implement the same refresh behavior.
+
+Refresh V2: revisions 069 - 813 
+Refresh V3: revisions 814+
+[/note]
+
 ## Step 1: Rollback
 
 When using the charm from charmhub:

--- a/kubernetes/docs/how-to/h-upgrade-minor.md
+++ b/kubernetes/docs/how-to/h-upgrade-minor.md
@@ -147,6 +147,13 @@ mysql-test-app/0*    active       idle   10.1.12.57
 
 If the upgrade was incompatible, it’s important to roll back the charm to a previous revision so that an update can be later attempted after a further inspection of the failure. See the [minor rollback](/t/12239) guide.
 
+[note type="caution"]
+**Warning:** Doing a rollback is only possible between revisions that implement the same refresh behavior.
+
+Refresh V2: revisions 069 - 813 
+Refresh V3: revisions 814+
+[/note]
+
 ## Step 7: Scale-back
 
 Case the application scale was changed for the upgrade procedure, it is now safe to scale it back to the desired unit count:

--- a/kubernetes/metadata.yaml
+++ b/kubernetes/metadata.yaml
@@ -51,6 +51,10 @@ peers:
     interface: tls
   cos:
     interface: cos
+  # Not used; kept to avoid uncaught exception during stop event when refreshing from v2 charm
+  # See src/migration_from_refresh_v2.py
+  upgrade-version-a:
+    interface: upgrade
   refresh-v-three:
     interface: refresh
   mysql-router-peers:

--- a/kubernetes/src/charm.py
+++ b/kubernetes/src/charm.py
@@ -38,6 +38,7 @@ import tenacity
 from charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
 
 import kubernetes_logrotate
+import migration_from_refresh_v2
 import relations.kubernetes_cos
 import rock
 
@@ -99,6 +100,7 @@ class KubernetesRouterCharm(common.abstract_charm.MySQLRouterCharm):
         self._peer_data = common.relations.secrets.RelationSecrets(self, self._PEER_RELATION_NAME)
 
         self.framework.observe(self.on.install, self._on_install)
+        migration_from_refresh_v2.main()
         try:
             self.refresh = charm_refresh.Kubernetes(
                 _KubernetesRouterRefresh(

--- a/kubernetes/src/migration_from_refresh_v2.py
+++ b/kubernetes/src/migration_from_refresh_v2.py
@@ -1,0 +1,227 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Migrate from refresh v2 charm with downtime"""
+
+import datetime
+import logging
+import time
+
+import charm_ as charm
+import charm_json
+import lightkube
+import lightkube.core.exceptions
+import lightkube.models.authorization_v1
+import lightkube.resources.apps_v1
+import lightkube.resources.authorization_v1
+import lightkube.resources.core_v1
+
+logger = logging.getLogger(__name__)
+
+
+# Derived from https://github.com/canonical/charm-refresh/blob/b6044ea4782ff43fdf0bc91ead088942b6054107/charm_refresh/_main.py#L536-L560
+class _KubernetesUnit(charm.Unit):
+    def __new__(cls, name: str, /, *, controller_revision: str, pod_uid: str, pod_name: str):
+        instance: _KubernetesUnit = super().__new__(cls, name)
+        instance.controller_revision = controller_revision
+        instance.pod_uid = pod_uid
+        instance.pod_name = pod_name
+        return instance
+
+    def __repr__(self):
+        return (
+            f"{type(self).__name__}({repr(str(self))}, "
+            f"controller_revision={repr(self.controller_revision)}, pod_uid={repr(self.pod_uid)}, "
+            f"pod_name={repr(self.pod_name)})"
+        )
+
+    @classmethod
+    def from_pod(cls, pod: lightkube.resources.core_v1.Pod, /):
+        # Example: "postgresql-k8s-0"
+        pod_name = pod.metadata.name
+        app_name, unit_number = pod_name.rsplit("-", maxsplit=1)
+        # Example: "postgresql-k8s/0"
+        unit_name = f"{app_name}/{unit_number}"
+        return cls(
+            unit_name,
+            controller_revision=pod.metadata.labels["controller-revision-hash"],
+            pod_uid=pod.metadata.uid,
+            pod_name=pod_name,
+        )
+
+
+def main():  # noqa: C901
+    """Migrate from refresh v2 charm with downtime
+
+    Emergency response to https://github.com/canonical/mysql-router-operators/issues/100
+
+    We made a mistake and released https://github.com/canonical/mysql-router-k8s-operator/pull/411
+    to stable without a migration or coordinating with users.
+
+    Now, we have stable releases with refresh v2 and refresh v3. We cannot revert PR#411 since some
+    users have already refreshed to v3 (and ran into issue #100).
+
+    To enable users on refresh v2 to refresh without the charm breaking, we added this migration.
+
+    This migration must stay in all future versions of the charm on this track (8.0) so that users
+    on refresh v2 can always refresh—users choose when to refresh, and when they refresh we cannot
+    require them to refresh to a specific revision (in most cases [i.e. by default] they will
+    refresh to the latest revision in the 8.0/stable track).
+
+    High-level design (after `juju refresh` from charm with refresh v2):
+    - Hold execution on all units
+    - Force all units' pods to be immediately updated to latest StatefulSet ControllerRevision
+      (i.e. units are refreshed all at once instead of one at a time)
+    - Resume execution after all pods are updated; refresh v3 detects this as initial install case
+      and recovers
+
+    This involves downtime (all units are offline while execution is held). In the best case, this
+    only lasts a few seconds.
+
+    Also, this migration does not support pausing, rollback to v2, or downgrade to v2.
+
+    This function:
+    1. If (initial install and (peer relation missing or Juju app deployed without `--trust`)) or
+       (teardown and peer relation missing), `return`.
+    2. Checks if the migration has already completed. If it has, `return`.
+    3. Checks if a refresh is in progress. If it is not, `return`.
+    4. Holds execution in an infinite loop until a refresh is no longer in progress:
+        - Get highest unit that has an outdated StatefulSet ControllerRevision
+        - Set StatefulSet partition to 0 and delete that unit
+        - Sleep
+
+    After this function first returns—except if it returns during #1—a refresh will not be in
+    progress (since all units have an up-to-date StatefulSet ControllerRevision). Refresh v3 will
+    run, detect this as the initial installation case (instead of as a refresh), and will set the
+    versions in its app databag. The versions being set in the app databag is used to track
+    completion of the migration.
+    """
+    refresh_v3_peer_relation = charm_json.PeerRelation.from_endpoint("refresh-v-three")
+    if not refresh_v3_peer_relation:
+        # Initial install
+        # Or teardown: https://github.com/juju/juju/issues/20713
+        return
+    if refresh_v3_peer_relation.my_app_ro.get("original_charm_version") is not None:
+        # Migration already completed
+        return
+
+    # Derived from https://github.com/canonical/charm-refresh/blob/b6044ea4782ff43fdf0bc91ead088942b6054107/charm_refresh/_main.py#L1367-L1386
+    # Check if Juju app was deployed with `--trust` (needed to call Kubernetes API)
+    if not (
+        lightkube.Client()
+        .create(
+            lightkube.resources.authorization_v1.SelfSubjectAccessReview(
+                spec=lightkube.models.authorization_v1.SelfSubjectAccessReviewSpec(
+                    resourceAttributes=lightkube.models.authorization_v1.ResourceAttributes(
+                        name=charm.app,
+                        namespace=charm.model,
+                        resource="statefulset",
+                        verb="patch",
+                    )
+                )
+            )
+        )
+        .status.allowed
+    ):
+        logger.warning(
+            f"Run `juju trust {charm.app} --scope=cluster`. Needed for in-place refreshes"
+        )
+        # Refresh v3 will set app status & raise exception so that charm.py
+        # `self._reconcile_allowed` is set to `False`
+        return
+
+    last_in_progress_log = None
+    while True:
+        app_controller_revision: str = (
+            lightkube.Client()
+            .get(lightkube.resources.apps_v1.StatefulSet, charm.app)
+            .status.updateRevision
+        )
+        assert app_controller_revision is not None
+
+        # Sorted from highest to lowest unit number
+        units = sorted(
+            (
+                _KubernetesUnit.from_pod(pod)
+                for pod in lightkube.Client().list(
+                    lightkube.resources.core_v1.Pod, labels={"app.kubernetes.io/name": charm.app}
+                )
+            ),
+            reverse=True,
+        )
+        highest_outdated_unit = next(
+            (unit for unit in units if unit.controller_revision != app_controller_revision), None
+        )
+        if highest_outdated_unit is None:
+            # Refresh not in progress
+            return
+
+        if last_in_progress_log is None or time.time() - last_in_progress_log > 60:
+            logger.info(
+                "Refresh migration in progress. All units will restart. Ignore app status and do "
+                "not run any action. Do not run `juju refresh`. If this application is stuck and "
+                "has repeatedly logged this message for longer than 15 minutes, please contact "
+                "the developers of this charm for support."
+            )
+            last_in_progress_log = time.time()
+        charm.unit_status = charm.MaintenanceStatus(
+            "Migration in progress. Do not run actions & do not run `juju refresh`. If stuck >15 "
+            "min, contact charm developers"
+        )
+        if charm.is_leader:
+            charm.app_status = charm.MaintenanceStatus(
+                "Refresh migration in progress. All units will restart. If this status is shown "
+                "for >15 minutes, contact charm developers"
+            )
+
+        if charm.unit != units[0]:
+            # This is not the highest unit number. Give the highest unit number 5 minutes to handle
+            # the migration itself (happy path) to avoid deleting already-updated pods. (There's a
+            # potential race between API call to list pods on unit A, unit B deleting a pod, and
+            # then unit A deleting the same pod. Theoretically the charm should be able to handle
+            # this without issues, but avoid this in happy path to reduce risk.)
+            last_refresh_time: datetime.datetime = (
+                lightkube.Client()
+                .get(lightkube.resources.apps_v1.ControllerRevision, app_controller_revision)
+                .metadata.creationTimestamp
+            )
+            assert last_refresh_time is not None
+
+            if datetime.datetime.now(
+                tz=datetime.timezone.utc
+            ) - last_refresh_time < datetime.timedelta(minutes=5):
+                logger.debug("Waiting up to 5 minutes for highest unit number to handle migration")
+                time.sleep(10)
+                continue
+
+        lightkube.Client().patch(
+            lightkube.resources.apps_v1.StatefulSet,
+            charm.app,
+            {"spec": {"updateStrategy": {"rollingUpdate": {"partition": 0}}}},
+        )
+        logger.info(f"Set partition to 0. Deleting pod {highest_outdated_unit.pod_name}")
+        try:
+            # Setting the partition to 0 is not enough to refresh all units.
+            # See https://canonical-charm-refresh.readthedocs-hosted.com/latest/juju-refresh/#kubernetes
+            # > After every restart of the charm container, the Juju agent will fail the pebble
+            # > health check until after the unit successfully executes the start event.
+            # Since we are holding execution, units will not successfully execute the start event
+            # and thus will not succeed the Kubernetes readiness probe* and allow the next pod to
+            # be refreshed. Instead of succeeding the readiness probe, delete the outdated pods so
+            # that they are re-created on the up-to-date StatefulSet ControllerRevision.
+            #
+            # * There is a race condition where pods will temporarily succeed the Kubernetes
+            #   readiness probe (see
+            #   https://canonical-charm-refresh.readthedocs-hosted.com/latest/juju-refresh/#kubernetes),
+            #   but we cannot rely on this.
+            lightkube.Client().delete(
+                lightkube.resources.core_v1.Pod, highest_outdated_unit.pod_name
+            )
+        except lightkube.core.exceptions.ApiError as exception:
+            if exception.status.code == 404:
+                # Pod not found
+                # Expected to occur if pod already deleted
+                pass
+            else:
+                raise
+        time.sleep(3)

--- a/kubernetes/src/migration_from_refresh_v2.py
+++ b/kubernetes/src/migration_from_refresh_v2.py
@@ -37,10 +37,10 @@ class _KubernetesUnit(charm.Unit):
 
     @classmethod
     def from_pod(cls, pod: lightkube.resources.core_v1.Pod, /):
-        # Example: "postgresql-k8s-0"
+        # Example: "mysql-k8s-0"
         pod_name = pod.metadata.name
         app_name, unit_number = pod_name.rsplit("-", maxsplit=1)
-        # Example: "postgresql-k8s/0"
+        # Example: "mysql-k8s/0"
         unit_name = f"{app_name}/{unit_number}"
         return cls(
             unit_name,

--- a/kubernetes/src/migration_from_refresh_v2.py
+++ b/kubernetes/src/migration_from_refresh_v2.py
@@ -165,13 +165,13 @@ def main():  # noqa: C901
             )
             last_in_progress_log = time.time()
         charm.unit_status = charm.MaintenanceStatus(
-            "Migration in progress. Do not run actions & do not run `juju refresh`. If stuck >15 "
-            "min, contact charm developers"
+            "Migration in progress. Ignore app status, do not run actions, do not run `juju "
+            "refresh`. If stuck >15 min, contact us"
         )
         if charm.is_leader:
             charm.app_status = charm.MaintenanceStatus(
-                "Refresh migration in progress. All units will restart. If this status is shown "
-                "for >15 minutes, contact charm developers"
+                "Migration in progress. Do not run actions and do not run `juju refresh`. If "
+                "stuck >15 min, contact charm developers"
             )
 
         if charm.unit != units[0]:

--- a/kubernetes/tests/integration/test_upgrade_from_v2.py
+++ b/kubernetes/tests/integration/test_upgrade_from_v2.py
@@ -32,7 +32,7 @@ RESOURCES = {"mysql-router-image": METADATA["resources"]["mysql-router-image"]["
 
 
 @pytest.mark.abort_on_fail
-async def test_deploy_v2(ops_test: OpsTest) -> None:
+async def test_deploy_v2(ops_test: OpsTest, series) -> None:
     """Deploy v2 charms and test application."""
     logger.info("Deploying all applications")
 
@@ -52,6 +52,7 @@ async def test_deploy_v2(ops_test: OpsTest) -> None:
             revision=mysql_rev,
             application_name=MYSQL_APP_NAME,
             config={"profile": "testing"},
+            series=series,
             num_units=1,
             trust=True,
         ),
@@ -60,6 +61,7 @@ async def test_deploy_v2(ops_test: OpsTest) -> None:
             channel="8.0/stable",
             revision=router_rev,
             application_name=MYSQL_ROUTER_APP_NAME,
+            series=series,
             num_units=3,
             trust=True,
         ),
@@ -67,6 +69,7 @@ async def test_deploy_v2(ops_test: OpsTest) -> None:
             "mysql-test-app",
             channel="latest/edge",
             application_name=APPLICATION_APP_NAME,
+            series=series,
             num_units=1,
         ),
     )

--- a/kubernetes/tests/integration/test_upgrade_from_v2.py
+++ b/kubernetes/tests/integration/test_upgrade_from_v2.py
@@ -1,0 +1,117 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+import time
+from pathlib import Path
+
+import pytest
+import yaml
+from pytest_operator.plugin import OpsTest
+
+from .architecture import architecture
+from .helpers import (
+    APPLICATION_DEFAULT_APP_NAME,
+    MYSQL_DEFAULT_APP_NAME,
+    MYSQL_ROUTER_DEFAULT_APP_NAME,
+    ensure_all_units_continuous_writes_incrementing,
+)
+
+logger = logging.getLogger(__name__)
+
+TIMEOUT = 20 * 60
+UPGRADE_TIMEOUT = 15 * 60
+
+MYSQL_APP_NAME = MYSQL_DEFAULT_APP_NAME
+MYSQL_ROUTER_APP_NAME = MYSQL_ROUTER_DEFAULT_APP_NAME
+APPLICATION_APP_NAME = APPLICATION_DEFAULT_APP_NAME
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+RESOURCES = {"mysql-router-image": METADATA["resources"]["mysql-router-image"]["upstream-source"]}
+
+
+@pytest.mark.abort_on_fail
+async def test_deploy_v2(ops_test: OpsTest) -> None:
+    """Deploy v2 charms and test application."""
+    logger.info("Deploying all applications")
+
+    if architecture == "amd64":
+        router_rev = 748
+        mysql_rev = 346
+    elif architecture == "arm64":
+        router_rev = 747
+        mysql_rev = 348
+    else:
+        pytest.skip(f"Architecture {architecture} not supported in this test")
+
+    await asyncio.gather(
+        ops_test.model.deploy(
+            "mysql-k8s",
+            channel="8.0/stable",
+            revision=mysql_rev,
+            application_name=MYSQL_APP_NAME,
+            config={"profile": "testing"},
+            num_units=1,
+            trust=True,
+        ),
+        ops_test.model.deploy(
+            "mysql-router-k8s",
+            channel="8.0/stable",
+            revision=router_rev,
+            application_name=MYSQL_ROUTER_APP_NAME,
+            num_units=3,
+            trust=True,
+        ),
+        ops_test.model.deploy(
+            "mysql-test-app",
+            channel="latest/edge",
+            application_name=APPLICATION_APP_NAME,
+            num_units=1,
+        ),
+    )
+
+    logger.info(f"Relating {MYSQL_ROUTER_APP_NAME} to {MYSQL_APP_NAME} and {APPLICATION_APP_NAME}")
+
+    await ops_test.model.relate(
+        f"{MYSQL_ROUTER_APP_NAME}:backend-database", f"{MYSQL_APP_NAME}:database"
+    )
+    await ops_test.model.relate(
+        f"{APPLICATION_APP_NAME}:database", f"{MYSQL_ROUTER_APP_NAME}:database"
+    )
+
+    mysql_router_application = ops_test.model.applications[MYSQL_ROUTER_APP_NAME]
+    logger.info("Waiting for applications to become active")
+    await ops_test.model.block_until(
+        lambda: (
+            all(unit.workload_status == "active" for unit in mysql_router_application.units)
+            and all(unit.agent_status == "idle" for unit in mysql_router_application.units)
+        ),
+        timeout=TIMEOUT,
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_upgrade_from_v2(ops_test: OpsTest, charm) -> None:
+    """Upgrade mysqlrouter from v2 to v3 while ensuring continuous writes incrementing."""
+    await ensure_all_units_continuous_writes_incrementing(ops_test)
+
+    mysql_router_application = ops_test.model.applications[MYSQL_ROUTER_APP_NAME]
+
+    logger.info("Refresh the charm with local v3 build")
+    await mysql_router_application.refresh(path=charm, resources=RESOURCES)
+
+    logger.info("Block until router become active")
+    # sleep to ensure that active status from before re-refresh does not affect below check
+    time.sleep(15)
+
+    await ops_test.model.block_until(
+        lambda: (
+            all(unit.workload_status == "active" for unit in mysql_router_application.units)
+            and all(unit.agent_status == "idle" for unit in mysql_router_application.units)
+        ),
+        timeout=TIMEOUT,
+    )
+
+    logger.info("Ensure continuous writes after upgrade")
+    await ensure_all_units_continuous_writes_incrementing(ops_test)

--- a/kubernetes/tests/spread/test_upgrade_from_v2.py/task.yaml
+++ b/kubernetes/tests/spread/test_upgrade_from_v2.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_upgrade_from_v2.py
+environment:
+  TEST_MODULE: test_upgrade_from_v2.py
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/kubernetes/tests/unit/conftest.py
+++ b/kubernetes/tests/unit/conftest.py
@@ -58,6 +58,7 @@ def patch(monkeypatch):
         "common.mysql_shell.Shell.is_router_in_cluster_set", lambda *args, **kwargs: True
     )
     monkeypatch.setattr("charm_refresh.Kubernetes", _MockRefresh)
+    monkeypatch.setattr("migration_from_refresh_v2.main", lambda *args, **kwargs: None)
     monkeypatch.setattr(
         "charm_refresh.CharmSpecificCommon.__post_init__", lambda *args, **kwargs: None
     )


### PR DESCRIPTION
Fixes https://github.com/canonical/mysql-router-operators/issues/100

We made a mistake and released https://github.com/canonical/mysql-router-k8s-operator/pull/411 to stable without a migration or coordinating with users.

Now, we have stable releases with refresh v2 and refresh v3. We cannot revert PR#411 since some users have already refreshed to v3 (and ran into issue #100).

To enable users on refresh v2 to refresh without the charm breaking, add a migration.

This migration must stay in all future versions of the charm on this track (8.0) so that users on refresh v2 can always refresh—users choose when to refresh, and when they refresh we cannot require them to refresh to a specific revision. (In most cases [i.e. by default] they will refresh to the latest revision in the 8.0/stable track).

High-level design (after `juju refresh` from charm with refresh v2):
- Hold execution on all units
- Force all units' pods to be immediately updated to latest StatefulSet ControllerRevision (i.e. units are refreshed all at once instead of one at a time)
- Resume execution after all pods are updated; refresh v3 detects this as initial install case and recovers

This involves downtime (all units are offline while execution is held). In the best case, this only lasts a few seconds.

Also, this migration does not support pausing, rollback to v2, or downgrade to v2.
