### PR TITLE
[DPE-8811] Bump minimum juju version

### DIFF
--- a/kubernetes/docs/how-to/h-deploy-microk8s.md
+++ b/kubernetes/docs/how-to/h-deploy-microk8s.md
@@ -20,7 +20,7 @@ juju status --watch 1s
 The expected result:
 ```shell 
 Model           Controller  Cloud/Region        Version  SLA          Timestamp
-wordpress-demo  microk8s    microk8s/localhost  3.1.6    unsupported  14:39:27+02:00
+wordpress-demo  microk8s    microk8s/localhost  3.6.19   unsupported  14:39:27+02:00
 
 App               Version  Status   Scale  Charm             Channel     Rev  Address         Exposed  Message
 mysql-k8s         8.4.7    active       1  mysql-k8s         8.4/stable   99  10.152.183.189  no       

--- a/kubernetes/docs/how-to/h-enable-monitoring.md
+++ b/kubernetes/docs/how-to/h-enable-monitoring.md
@@ -89,7 +89,7 @@ An example of `juju status` on Charmed MySQL Router K8s model:
 ```shell
 ubuntu@localhost:~$ juju status
 Model 	  Controller  Cloud/Region    	  Version  SLA          Timestamp
-database  k8s     	  microk8s/localhost  3.1.8	   unsupported  13:27:08Z
+database  k8s     	  microk8s/localhost  3.6.19   unsupported  13:27:08Z
 
 SAAS    	Status  Store  URL
 grafana 	active  k8s	   admin/cos.grafana
@@ -114,7 +114,7 @@ An example of `juju status` on the COS K8s model:
 ```shell
 ubuntu@localhost:~$ juju status
 Model  Controller  Cloud/Region        Version  SLA          Timestamp
-cos	   k8s     	   microk8s/localhost  3.1.8    unsupported  13:28:02Z
+cos	   k8s     	   microk8s/localhost  3.6.19   unsupported  13:28:02Z
 
 App       	  Version  Status  Scale  Charm          Channel  Rev  Address     	   Exposed  Message
 alertmanager  0.27.0   active  	1  alertmanager-k8s  stable   106  10.152.183.197  no  	 

--- a/kubernetes/docs/how-to/h-enable-tracing.md
+++ b/kubernetes/docs/how-to/h-enable-tracing.md
@@ -93,7 +93,7 @@ Wait until the model settles. The following is an example of the `juju status --
 
 ```shell
 Model     Controller  Cloud/Region        Version  SLA          Timestamp
-database  k8s         microk8s/localhost  3.5.4    unsupported  18:32:28Z
+database  k8s         microk8s/localhost  3.6.19   unsupported  18:32:28Z
 
 SAAS   Status  Store       URL
 tempo  active  k8s         admin/cos.tempo

--- a/kubernetes/docs/how-to/h-external-access.md
+++ b/kubernetes/docs/how-to/h-external-access.md
@@ -9,7 +9,7 @@ Below is a juju model where MySQL Router K8s is related to MySQL K8s and Data In
 ```shell
 $ juju status --relations
 Model     Controller  Cloud/Region        Version  SLA          Timestamp
-database  uk8s-3-6-1  microk8s/localhost  3.6.1    unsupported  14:39:08Z
+database  uk8s-3-6-1  microk8s/localhost  3.6.19   unsupported  14:39:08Z
 
 App               Version  Status  Scale  Charm             Channel        Rev  Address         Exposed  Message
 data-integrator            active      1  data-integrator   latest/stable   78  10.152.183.44   no       

--- a/kubernetes/docs/how-to/h-upgrade-minor.md
+++ b/kubernetes/docs/how-to/h-upgrade-minor.md
@@ -35,7 +35,7 @@ The first step is to record the revision of the running application, as a safety
 
 ```shell
 Model    Controller  Cloud/Region        Version  SLA          Timestamp
-upgrade  microk8s    microk8s/localhost  3.1.6    unsupported  15:32:04+02:00
+upgrade  microk8s    microk8s/localhost  3.6.19   unsupported  15:32:04+02:00
 
 App               Version  Status  Scale  Charm             Channel     Rev  Address         Exposed  Message
 mysql-k8s         8.4.7    active      3  mysql-k8s         8.4/stable   99  10.152.183.238  no       
@@ -118,7 +118,7 @@ The `resume-upgrade` will roll out the Server upgrade for the following unit, al
 
 ```shell
 Model    Controller  Cloud/Region        Version  SLA          Timestamp
-upgrade  microk8s    microk8s/localhost  3.1.6    unsupported  15:56:25+02:00
+upgrade  microk8s    microk8s/localhost  3.6.19   unsupported  15:56:25+02:00
 
 App               Version  Status   Scale  Charm             Channel   Rev  Address         Exposed  Message
 mysql-k8s         8.4.7    waiting    3/4  mysql-k8s         8.4/edge  109  10.152.183.238  no       installing agent

--- a/kubernetes/docs/reference/r-system-requirements.md
+++ b/kubernetes/docs/reference/r-system-requirements.md
@@ -1,8 +1,6 @@
 ## Juju version
 
-The charm supports only [Juju 3.1+](https://github.com/juju/juju/releases).
-
-The minimum supported Juju versions is 3.1.7+ (Juju secrets refactored/stabilized in Juju 3.1.7)
+The charm supports only [Juju 3.6+](https://github.com/juju/juju/releases).
 
 ## Kubernetes requirements
 

--- a/kubernetes/docs/tutorial/t-deploy.md
+++ b/kubernetes/docs/tutorial/t-deploy.md
@@ -19,7 +19,7 @@ juju status --watch 1s
 This command is useful for checking the status of Juju applications and gathering information about the machines hosting them. Some of the helpful information it displays include IP addresses, ports, state, etc. The command updates the status of charms every second and as the application starts you can watch the status and messages of their change. Wait until the application is ready - when it is ready, `juju status` will show:
 ```shell
 Model     Controller  Cloud/Region        Version  SLA          Timestamp
-tutorial  overlord    microk8s/localhost  3.4.3    unsupported  22:33:45+01:00
+tutorial  overlord    microk8s/localhost  3.6.19   unsupported  22:33:45+01:00
 
 App               Version  Status   Scale  Charm             Channel   Rev  Address        Exposed  Message
 mysql-k8s         8.4.7    active       1  mysql-k8s         8.4/edge  109  10.152.183.68  no       
@@ -47,7 +47,7 @@ juju relate data-integrator mysql-router-k8s
 In a couple of seconds, the status will be happy for entire model:
 ```shell
 Model     Controller  Cloud/Region        Version  SLA          Timestamp
-tutorial  overlord    microk8s/localhost  3.4.3   unsupported  22:37:41+01:00
+tutorial  overlord    microk8s/localhost  3.6.19   unsupported  22:37:41+01:00
 
 App               Version  Status  Scale  Charm             Channel   Rev  Address         Exposed  Message
 data-integrator            active      1  data-integrator   stable     13  10.152.183.142  no       

--- a/kubernetes/docs/tutorial/t-enable-tls.md
+++ b/kubernetes/docs/tutorial/t-enable-tls.md
@@ -26,8 +26,8 @@ juju deploy self-signed-certificates --config ca-common-name="Tutorial CA"
 
 Wait until `self-signed-certificates` is up and active with `juju status --watch 1s` to monitor the progress.
 ```shell
-Model 	Controller  Cloud/Region    	Version  SLA      	Timestamp
-database  k8s     	microk8s/localhost  3.1.8	unsupported  12:10:33Z
+Model 	  Controller  Cloud/Region    	  Version  SLA          Timestamp
+database  k8s     	  microk8s/localhost  3.6.19   unsupported  12:10:33Z
 
 App                   	Version  Status  Scale  Charm                 	 Channel 	 Rev  Address     	  Exposed  Message
 mysql-k8s             	8.4.7    active  	1  mysql-k8s             	 8.4/stable  127  10.152.183.101  no  	 

--- a/kubernetes/docs/tutorial/t-manage-units.md
+++ b/kubernetes/docs/tutorial/t-manage-units.md
@@ -15,7 +15,7 @@ juju scale-application mysql-router-k8s 3
 You can now watch the scaling process in live using: `juju status --watch 1s`. It usually takes several minutes for new cluster members to be added. You’ll know that all three nodes are in sync when `juju status` reports `Workload=active` and `Agent=idle`:
 ```shell
 Model     Controller  Cloud/Region        Version  SLA          Timestamp
-tutorial  overlord    microk8s/localhost  3.4.3    unsupported  22:48:57+01:00
+tutorial  overlord    microk8s/localhost  3.6.19   unsupported  22:48:57+01:00
 
 App               Version  Status  Scale  Charm             Channel   Rev  Address         Exposed  Message
 data-integrator            active      1  data-integrator   stable     13  10.152.183.142  no       
@@ -61,7 +61,7 @@ juju scale-application mysql-k8s 2
 You’ll know that the replica was successfully removed when `juju status --watch 1s` reports:
 ```shell
 Model     Controller  Cloud/Region        Version  SLA          Timestamp
-tutorial  overlord    microk8s/localhost  3.4.3    unsupported  22:48:57+01:00
+tutorial  overlord    microk8s/localhost  3.6.19   unsupported  22:48:57+01:00
 
 App               Version  Status  Scale  Charm             Channel   Rev  Address         Exposed  Message
 data-integrator            active      1  data-integrator   stable     13  10.152.183.142  no       

--- a/kubernetes/metadata.yaml
+++ b/kubernetes/metadata.yaml
@@ -70,5 +70,5 @@ assumes:
   - k8s-api
   - any-of:
     - all-of:
-      - juju >= 3.1.7
+      - juju >= 3.6.0
       - juju < 4

--- a/machines/docs/how-to/h-deploy-lxd.md
+++ b/machines/docs/how-to/h-deploy-lxd.md
@@ -21,7 +21,7 @@ juju status --watch 1s
 The expected result:
 ```shell
 Model  Controller  Cloud/Region         Version  SLA          Timestamp
-mysql  lxd         localhost/localhost  3.1.6    unsupported  11:57:33+02:00
+mysql  lxd         localhost/localhost  3.6.19   unsupported  11:57:33+02:00
 
 App             Version  Status  Scale  Charm           Channel     Rev  Exposed  Message
 mysql           8.4.7    active      1  mysql           8.4/edge    196  no       

--- a/machines/docs/how-to/h-enable-monitoring.md
+++ b/machines/docs/how-to/h-enable-monitoring.md
@@ -84,7 +84,7 @@ Example of `juju status` on the Charmed MySQL Router VM model:
 ```shell
 ubuntu@localhost:~$ juju status
 Model 	  Controller  Cloud/Region         Version  SLA          Timestamp
-database  lxd     	  localhost/localhost    3.1.8	unsupported  12:34:26Z
+database  lxd     	  localhost/localhost  3.6.19   unsupported  12:34:26Z
 
 SAAS    	Status  Store  URL
 grafana 	active  k8s	   admin/cos.grafana
@@ -113,7 +113,7 @@ Example of `juju status` on the COS K8s model:
 ```shell
 ubuntu@localhost:~$ juju status
 Model  Controller  Cloud/Region    	   Version  SLA      	Timestamp
-cos	   k8s     	   microk8s/localhost  3.1.8	unsupported  20:29:12Z
+cos	   k8s     	   microk8s/localhost  3.6.19   unsupported  20:29:12Z
 
 App       	  Version  Status  Scale  Charm             Channel  Rev  Address         Exposed  Message
 alertmanager  0.27.0   active  	   1  alertmanager-k8s  stable   106  10.152.183.197  no  	 

--- a/machines/docs/how-to/h-enable-tracing.md
+++ b/machines/docs/how-to/h-enable-tracing.md
@@ -100,7 +100,7 @@ Wait until the model settles. The following is an example of the `juju status --
 
 ```shell
 Model     Controller  Cloud/Region         Version  SLA          Timestamp
-database  lxd         localhost/localhost  3.4.3    unsupported  12:48:46Z
+database  lxd         localhost/localhost  3.6.19   unsupported  12:48:46Z
 
 SAAS       Status  Store  URL
 tempo-k8s  active  uk8s   admin/cos.tempo-k8s

--- a/machines/docs/reference/r-system-requirements.md
+++ b/machines/docs/reference/r-system-requirements.md
@@ -1,8 +1,6 @@
 ## Juju version
 
-The charm supports only [Juju 3.1+](https://github.com/juju/juju/releases).
-
-The minimum supported Juju versions is 3.1.7+ (Juju secrets refactored/stabilized in Juju 3.1.7)
+The charm supports only [Juju 3.6+](https://github.com/juju/juju/releases).
 
 Make sure your machine meets the following requirements:
 - Ubuntu 24.04 (Jammy) or later.

--- a/machines/docs/tutorial/t-enable-security.md
+++ b/machines/docs/tutorial/t-enable-security.md
@@ -30,7 +30,7 @@ Wait until the `self-signed-certificates` is up and active, then use `juju statu
 
 ```
 Model 	Controller  Cloud/Region     	Version  SLA      	Timestamp
-database  lxd     	localhost/localhost  3.1.8	unsupported  18:47:51Z
+database  lxd     	localhost/localhost  3.6.19	 unsupported  18:47:51Z
 
 App                   	Version  Status  Scale  Charm                 	  Channel 	  Rev  Exposed  Message
 mysql                 	8.4.7    active  	1   mysql                 	  8.4/stable  196  no  	 

--- a/machines/docs/tutorial/t-managing-units.md
+++ b/machines/docs/tutorial/t-managing-units.md
@@ -15,7 +15,7 @@ juju scale-application mysql-router 3
 You can now watch the scaling process in live using: `juju status --watch 1s`. It usually takes several minutes for new cluster members to be added. You’ll know that all three nodes are in sync when `juju status` reports `Workload=active` and `Agent=idle`:
 ```shell
 Model     Controller  Cloud/Region        Version  SLA          Timestamp
-tutorial  overlord    microk8s/localhost  3.4.3    unsupported  22:48:57+01:00
+tutorial  overlord    microk8s/localhost  3.6.19   unsupported  22:48:57+01:00
 
 App               Version  Status  Scale  Charm             Channel   Rev  Address         Exposed  Message
 data-integrator            active      1  data-integrator   stable     13  10.152.183.142  no       
@@ -61,7 +61,7 @@ juju scale-application mysql 2
 You’ll know that the replica was successfully removed when `juju status --watch 1s` reports:
 ```shell
 Model     Controller  Cloud/Region        Version  SLA          Timestamp
-tutorial  overlord    microk8s/localhost  3.4.3    unsupported  22:48:57+01:00
+tutorial  overlord    microk8s/localhost  3.6.19   unsupported  22:48:57+01:00
 
 App               Version  Status  Scale  Charm             Channel   Rev  Address         Exposed  Message
 data-integrator            active      1  data-integrator   stable     13  10.152.183.142  no       

--- a/machines/docs/tutorial/t-setup-environment.md
+++ b/machines/docs/tutorial/t-setup-environment.md
@@ -41,7 +41,7 @@ juju add-model tutorial
 You can now view the model you created above by entering the command `juju status` into the command line. You should see the following:
 ```
 Model    Controller  Cloud/Region         Version  SLA          Timestamp
-tutorial overlord    localhost/localhost  3.1.6    unsupported  23:20:53+01:00
+tutorial overlord    localhost/localhost  3.6.19   unsupported  23:20:53+01:00
 
 Model "admin/tutorial" is empty.
 ```

--- a/machines/metadata.yaml
+++ b/machines/metadata.yaml
@@ -62,5 +62,5 @@ peers:
 assumes:
   - any-of:
     - all-of:
-      - juju >= 3.1.7
+      - juju >= 3.6.0
       - juju < 4


### PR DESCRIPTION
This PR bumps the minimum required juju version for the MySQL Router 8.4 charm to `3.6.0`.

Now MySQL Server and MySQL Router 8.4 have the same requirements.