### PR TITLE
[MISC] 8.4 - Fix spread installation path

### DIFF
--- a/.github/workflows/integration_test_charm.yaml
+++ b/.github/workflows/integration_test_charm.yaml
@@ -25,7 +25,7 @@ jobs:
         run: |
           sudo snap install charmcraft --classic
           sudo snap install go --classic
-          go install github.com/snapcore/spread/cmd/spread@latest
+          go install github.com/canonical/spread/cmd/spread@latest
           pipx install tox poetry
       - name: Collect spread jobs
         id: collect-jobs
@@ -115,7 +115,7 @@ jobs:
         run: |
           sudo snap install charmcraft --classic
           sudo snap install go --classic
-          go install github.com/snapcore/spread/cmd/spread@latest
+          go install github.com/canonical/spread/cmd/spread@latest
       - name: Download packed charm(s)
         timeout-minutes: 5
         uses: actions/download-artifact@v6


### PR DESCRIPTION
This PR fixes our CI after the snap team moved `spread` to Canonical organization.
