### PR TITLE
[MISC] 8.4 - Enabling scaling test

### DIFF
--- a/kubernetes/tests/integration/test_charm.py
+++ b/kubernetes/tests/integration/test_charm.py
@@ -121,12 +121,10 @@ async def test_database_relation(ops_test: OpsTest, charm):
     assert len(selected_data) > 0
     assert inserted_data == selected_data[0]
 
-    # Ensure that both mysqlrouter and the application can be scaled up and down
+    # Ensure that both mysqlrouter and the application can be scaled up
     await scale_application(ops_test, MYSQL_ROUTER_APP_NAME, 2)
-    # Scaling the application will ensure that it can read the inserted data
-    # from the mysqlrouter connection before going into an active status
     await scale_application(ops_test, APPLICATION_APP_NAME, 2)
 
-    # Disabled until juju fixes k8s scaledown: https://bugs.launchpad.net/juju/+bug/1977582
-    # await scale_application(ops_test, MYSQL_ROUTER_APP_NAME, 1)
-    # await scale_application(ops_test, APPLICATION_APP_NAME, 1)
+    # Ensure that both mysqlrouter and the application can be scaled down
+    await scale_application(ops_test, MYSQL_ROUTER_APP_NAME, 1)
+    await scale_application(ops_test, APPLICATION_APP_NAME, 1)


### PR DESCRIPTION
This PR re-enables the scaling up and down testing that was left disabled long ago due to a Juju 2.9 bug.
