### PR TITLE
[DPE-7912] Standardized operator user names

### DIFF
--- a/kubernetes/tests/integration/helpers.py
+++ b/kubernetes/tests/integration/helpers.py
@@ -33,7 +33,6 @@ MYSQL_DEFAULT_APP_NAME = "mysql-k8s"
 MYSQL_ROUTER_DEFAULT_APP_NAME = "mysql-router-k8s"
 APPLICATION_DEFAULT_APP_NAME = "mysql-test-app"
 
-SERVER_CONFIG_USERNAME = "serverconfig"
 CONTAINER_NAME = "mysql-router"
 LOGROTATE_EXECUTOR_SERVICE = "logrotate_executor"
 
@@ -78,7 +77,7 @@ async def execute_queries_against_unit(
     return output
 
 
-async def get_server_config_credentials(unit: Unit) -> dict:
+async def get_operator_credentials(unit: Unit) -> dict:
     """Helper to run an action to retrieve server config credentials.
 
     Args:
@@ -87,7 +86,7 @@ async def get_server_config_credentials(unit: Unit) -> dict:
     Returns:
         A dictionary with the server config username and password
     """
-    return await run_action(unit, "get-password", username=SERVER_CONFIG_USERNAME)
+    return await run_action(unit, "get-password", username="charmed-operator")
 
 
 async def get_inserted_data_by_application(unit: Unit) -> str | None:
@@ -565,10 +564,10 @@ async def ensure_all_units_continuous_writes_incrementing(
 
     primary = await get_primary_unit_wrapper(ops_test, mysql_application_name)
 
-    server_config_credentials = await get_server_config_credentials(mysql_units[0])
+    operator_credentials = await get_operator_credentials(mysql_units[0])
 
     last_max_written_value = await get_max_written_value_in_database(
-        ops_test, primary, server_config_credentials
+        ops_test, primary, operator_credentials
     )
 
     select_all_continuous_writes_sql = [
@@ -586,7 +585,7 @@ async def ensure_all_units_continuous_writes_incrementing(
 
                     # ensure the max written value is incrementing (continuous writes is active)
                     max_written_value = await get_max_written_value_in_database(
-                        ops_test, unit, server_config_credentials
+                        ops_test, unit, operator_credentials
                     )
                     assert max_written_value > last_max_written_value, (
                         "Continuous writes not incrementing"
@@ -596,8 +595,8 @@ async def ensure_all_units_continuous_writes_incrementing(
                     all_written_values = set(
                         await execute_queries_against_unit(
                             unit_address,
-                            server_config_credentials["username"],
-                            server_config_credentials["password"],
+                            operator_credentials["username"],
+                            operator_credentials["password"],
                             select_all_continuous_writes_sql,
                         )
                     )

--- a/kubernetes/tests/integration/test_charm.py
+++ b/kubernetes/tests/integration/test_charm.py
@@ -17,7 +17,7 @@ from .helpers import (
     MYSQL_ROUTER_DEFAULT_APP_NAME,
     execute_queries_against_unit,
     get_inserted_data_by_application,
-    get_server_config_credentials,
+    get_operator_credentials,
     get_unit_address,
     scale_application,
 )
@@ -106,15 +106,15 @@ async def test_database_relation(ops_test: OpsTest, charm):
 
     mysql_unit = mysql_app.units[0]
     mysql_unit_address = await get_unit_address(ops_test, mysql_unit.name)
-    server_config_credentials = await get_server_config_credentials(mysql_unit)
+    operator_credentials = await get_operator_credentials(mysql_unit)
 
     select_inserted_data_sql = [
         f"SELECT data FROM continuous_writes.random_data WHERE data = '{inserted_data}'",
     ]
     selected_data = await execute_queries_against_unit(
         mysql_unit_address,
-        server_config_credentials["username"],
-        server_config_credentials["password"],
+        operator_credentials["username"],
+        operator_credentials["password"],
         select_inserted_data_sql,
     )
 

--- a/machines/tests/integration/helpers.py
+++ b/machines/tests/integration/helpers.py
@@ -24,7 +24,7 @@ MYSQL_ROUTER_DEFAULT_APP_NAME = "mysql-router"
 APPLICATION_DEFAULT_APP_NAME = "mysql-test-app"
 
 
-async def get_server_config_credentials(unit: Unit) -> dict:
+async def get_operator_credentials(unit: Unit) -> dict:
     """Helper to run an action to retrieve server config credentials from mysql unit.
 
     Must be run with a mysql unit.
@@ -35,7 +35,7 @@ async def get_server_config_credentials(unit: Unit) -> dict:
     Returns:
         A dictionary with the server config username and password
     """
-    return await run_action(unit, "get-password", username="serverconfig")
+    return await run_action(unit, "get-password", username="charmed-operator")
 
 
 async def get_inserted_data_by_application(unit: Unit) -> str | None:
@@ -362,10 +362,10 @@ async def ensure_all_units_continuous_writes_incrementing(
 
     primary = await get_primary_unit_wrapper(ops_test, mysql_application_name)
 
-    server_config_credentials = await get_server_config_credentials(mysql_units[0])
+    operator_credentials = await get_operator_credentials(mysql_units[0])
 
     last_max_written_value = await get_max_written_value_in_database(
-        ops_test, primary, server_config_credentials
+        ops_test, primary, operator_credentials
     )
 
     select_all_continuous_writes_sql = [
@@ -383,7 +383,7 @@ async def ensure_all_units_continuous_writes_incrementing(
 
                     # ensure the max written value is incrementing (continuous writes is active)
                     max_written_value = await get_max_written_value_in_database(
-                        ops_test, unit, server_config_credentials
+                        ops_test, unit, operator_credentials
                     )
                     assert max_written_value > last_max_written_value, (
                         "Continuous writes not incrementing"
@@ -393,8 +393,8 @@ async def ensure_all_units_continuous_writes_incrementing(
                     all_written_values = set(
                         await execute_queries_against_unit(
                             unit_address,
-                            server_config_credentials["username"],
-                            server_config_credentials["password"],
+                            operator_credentials["username"],
+                            operator_credentials["password"],
                             select_all_continuous_writes_sql,
                         )
                     )

--- a/machines/tests/integration/test_database.py
+++ b/machines/tests/integration/test_database.py
@@ -14,7 +14,7 @@ from .helpers import (
     MYSQL_ROUTER_DEFAULT_APP_NAME,
     execute_queries_against_unit,
     get_inserted_data_by_application,
-    get_server_config_credentials,
+    get_operator_credentials,
 )
 
 logger = logging.getLogger(__name__)
@@ -111,15 +111,15 @@ async def test_database_relation(ops_test: OpsTest, charm, ubuntu_base) -> None:
 
     mysql_unit = mysql_app.units[0]
     mysql_unit_address = await mysql_unit.get_public_address()
-    server_config_credentials = await get_server_config_credentials(mysql_unit)
+    operator_credentials = await get_operator_credentials(mysql_unit)
 
     select_inserted_data_sql = (
         f"SELECT data FROM `{TEST_DATABASE}`.{TEST_TABLE} WHERE data = '{inserted_data}'",
     )
     selected_data = await execute_queries_against_unit(
         mysql_unit_address,
-        server_config_credentials["username"],
-        server_config_credentials["password"],
+        operator_credentials["username"],
+        operator_credentials["password"],
         select_inserted_data_sql,
     )
 


### PR DESCRIPTION
This PR updates the integration tests to use the new MySQL Server standardized users introduced in [this PR]( https://github.com/canonical/mysql-operators/pull/122).
