### PR TITLE
[MISC] 8.4 - Downgrade CI runners to Ubuntu 22.04

### DIFF
--- a/.github/workflows/integration_test_charm.yaml
+++ b/.github/workflows/integration_test_charm.yaml
@@ -110,6 +110,10 @@ jobs:
       - name: Checkout
         timeout-minutes: 3
         uses: actions/checkout@v5
+      - name: Install Python for tests
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
       - name: Set up environment
         timeout-minutes: 5
         run: |

--- a/kubernetes/spread.yaml
+++ b/kubernetes/spread.yaml
@@ -80,16 +80,20 @@ backends:
       EOF
 
       sudo passwd --delete "$USER"
+      
+      sudo systemctl reload ssh || sudo systemctl restart ssh
 
       ADDRESS localhost
     # HACK: spread does not pass environment variables set on runner
     # Manually pass specific environment variables
     environment:
       CI: '$(HOST: echo $CI)'
+      LD_LIBRARY_PATH: '$(HOST: echo $LD_LIBRARY_PATH)'
+      PKG_CONFIG_PATH: '$(HOST: echo $PKG_CONFIG_PATH)'
     systems:
-      - ubuntu-24.04:
+      - ubuntu-22.04:
           username: runner
-      - ubuntu-24.04-arm:
+      - ubuntu-22.04-arm:
           username: runner
           variants:
             - -juju29
@@ -104,6 +108,7 @@ kill-timeout: 3h
 environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
   CONCIERGE_JUJU_CHANNEL/juju36: 3.6/stable
+  pythonLocation: '$(HOST: echo $pythonLocation)'
 prepare: |
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"
@@ -114,6 +119,7 @@ prepare: |
   concierge prepare --trace
 
   pipx install tox poetry
+  poetry env use $pythonLocation/bin/python
 prepare-each: |
   cd "$SPREAD_PATH"
   concierge prepare --trace
@@ -121,3 +127,5 @@ prepare-each: |
   # Unable to set constraint on all models because of Juju bug:
   # https://bugs.launchpad.net/juju/+bug/2065050
   juju set-model-constraints arch="$(dpkg --print-architecture)"
+  
+  poetry env use $pythonLocation/bin/python

--- a/machines/spread.yaml
+++ b/machines/spread.yaml
@@ -80,6 +80,8 @@ backends:
       EOF
 
       sudo passwd --delete "$USER"
+      
+      sudo systemctl reload ssh || sudo systemctl restart ssh
 
       ADDRESS localhost
     # HACK: spread does not pass environment variables set on runner
@@ -89,10 +91,12 @@ backends:
       UBUNTU_PRO_TOKEN: '$(HOST: echo $UBUNTU_PRO_TOKEN)'
       LANDSCAPE_ACCOUNT_NAME: '$(HOST: echo $LANDSCAPE_ACCOUNT_NAME)'
       LANDSCAPE_REGISTRATION_KEY: '$(HOST: echo $LANDSCAPE_REGISTRATION_KEY)'
+      LD_LIBRARY_PATH: '$(HOST: echo $LD_LIBRARY_PATH)'
+      PKG_CONFIG_PATH: '$(HOST: echo $PKG_CONFIG_PATH)'
     systems:
-      - ubuntu-24.04:
+      - ubuntu-22.04:
           username: runner
-      - ubuntu-24.04-arm:
+      - ubuntu-22.04-arm:
           username: runner
 
 suites:
@@ -105,6 +109,7 @@ kill-timeout: 3h
 environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
   CONCIERGE_JUJU_CHANNEL/juju36: 3.6/stable
+  pythonLocation: '$(HOST: echo $pythonLocation)'
 prepare: |
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"
@@ -115,6 +120,7 @@ prepare: |
   concierge prepare --trace
 
   pipx install tox poetry
+  poetry env use $pythonLocation/bin/python
 prepare-each: |
   cd "$SPREAD_PATH"
   concierge prepare --trace
@@ -122,3 +128,5 @@ prepare-each: |
   # Unable to set constraint on all models because of Juju bug:
   # https://bugs.launchpad.net/juju/+bug/2065050
   juju set-model-constraints arch="$(dpkg --print-architecture)"
+  
+  poetry env use $pythonLocation/bin/python


### PR DESCRIPTION
This PR follows the lead of MySQL Server PR https://github.com/canonical/mysql-operators/pull/198 in order to temporarily downgrade CI runners to Ubuntu 22.04, until the AppArmor fix get backported to Ubuntu 24.04 (probably after 26.04 gets released).
