### PR TITLE
[MISC] Cleanup Juju 2.9 spread variant

### DIFF
--- a/kubernetes/spread.yaml
+++ b/kubernetes/spread.yaml
@@ -95,8 +95,6 @@ backends:
           username: runner
       - ubuntu-22.04-arm:
           username: runner
-          variants:
-            - -juju29
 
 suites:
   tests/spread/:


### PR DESCRIPTION
This PR cleanups a leftover spread variant from MySQL Router 8.4 branch.
