### PR TITLE
[MISC] 8.0 - Rootless K8s container

### DIFF
--- a/kubernetes/metadata.yaml
+++ b/kubernetes/metadata.yaml
@@ -17,9 +17,12 @@ website:
   - https://chat.charmhub.io/charmhub/channels/data-platform
 maintainers:
   - Canonical Data Platform <data-platform@lists.launchpad.net>
+charm-user: non-root
 
 containers:
   mysql-router:
+    uid: 584788
+    gid: 584788
     resource: mysql-router-image
 provides:
   database:
@@ -63,6 +66,6 @@ resources:
   mysql-router-image:
     type: oci-image
     description: OCI image for mysql-router
-    upstream-source: ghcr.io/canonical/charmed-mysql@sha256:672f20830d66678a3ece7285048700d6e52a9393202eb51e9749eb35031559c4
+    upstream-source: ghcr.io/canonical/charmed-mysql@sha256:82013980ad6da9b09d62348c02ece1c0ebf5847f8c0af62d341555122d2bd7ca
 assumes:
   - k8s-api


### PR DESCRIPTION
This PR updates the MySQL Router K8s charm to make the workload container a root-less one.
