### PR TITLE
[MISC] Add read permission for actions in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,7 @@ jobs:
     with:
       track: '8.4'
     permissions:
+      actions: read
       contents: write  # Needed to create git tag
 
   ci-tests:


### PR DESCRIPTION
## Issue

Turns out [I was missing 1 more](https://github.com/canonical/mysql-router-operators/actions/runs/24390748092)... sorry folks.

Follow-up on #130

## Solution
