### PR TITLE
[MISC] 8.0 - Cleanup repo mirroring

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,23 +53,3 @@ jobs:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
     permissions:
       contents: write  # Needed to create git tags
-
-  mirror:
-    strategy:
-      matrix:
-        charm:
-          - path: kubernetes
-            repo: canonical/mysql-router-k8s-operator
-          - path: machines
-            repo: canonical/mysql-router-operator
-    name: Mirror charm | ${{ matrix.charm.path }}
-    needs:
-      - release
-    uses: canonical/data-platform-workflows/.github/workflows/_mirror_charm.yaml@v49
-    with:
-      path-to-charm-directory: ${{ matrix.charm.path }}
-      repository: ${{ matrix.charm.repo }}
-    secrets:
-      token: ${{ secrets.MIRROR_REPOS_PAT }}
-    permissions:
-      contents: read


### PR DESCRIPTION
This PR removes the MySQL 8.0 mirroring to substrate specific repos. When this PR gets merged, we could:
- Remove `archive/kubernetes` branch.
- Remove `archive/machines` branch.
- Remove `MIRROR_REPOS_PAT` secret.