### PR TITLE
[MISC] 8.0 - Fix release workflow permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,7 @@ jobs:
     with:
       track: 'dpe'
     permissions:
+      actions: read
       contents: write  # Needed to create git tag
 
   build:
@@ -79,4 +80,5 @@ jobs:
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
     permissions:
+      actions: read
       contents: write  # Needed to create git tags


### PR DESCRIPTION
This PR fixes the `release.yaml` workflow permissions after the migration to Data Platform workflows v49.
