### PR TITLE
[DPE-9970] 8.4 - Migrate tests to use Juju CLI

### DIFF
--- a/kubernetes/tests/integration/integration/test_architecture.py
+++ b/kubernetes/tests/integration/integration/test_architecture.py
@@ -18,16 +18,17 @@ async def test_arm_charm_on_amd_host(ops_test: OpsTest) -> None:
     """Tries deploying an arm64 charm on amd64 host."""
     charm = "./mysql-router-k8s_ubuntu@24.04-arm64.charm"
 
-    resources = {
-        "mysql-router-image": METADATA["resources"]["mysql-router-image"]["upstream-source"]
-    }
+    resource_args = [
+        f"--resource=mysql-router-image={METADATA['resources']['mysql-router-image']['upstream-source']}",
+    ]
 
-    await ops_test.model.deploy(
+    await ops_test.juju(
+        "deploy",
         charm,
-        application_name=MYSQL_ROUTER_APP_NAME,
-        num_units=1,
-        resources=resources,
-        base="ubuntu@24.04",
+        MYSQL_ROUTER_APP_NAME,
+        *resource_args,
+        "--base=ubuntu@24.04",
+        "--num-units=1",
     )
 
     await ops_test.model.wait_for_idle(
@@ -42,16 +43,17 @@ async def test_amd_charm_on_arm_host(ops_test: OpsTest) -> None:
     """Tries deploying an amd64 charm on arm64 host."""
     charm = "./mysql-router-k8s_ubuntu@24.04-amd64.charm"
 
-    resources = {
-        "mysql-router-image": METADATA["resources"]["mysql-router-image"]["upstream-source"]
-    }
+    resource_args = [
+        f"--resource=mysql-router-image={METADATA['resources']['mysql-router-image']['upstream-source']}",
+    ]
 
-    await ops_test.model.deploy(
+    await ops_test.juju(
+        "deploy",
         charm,
-        application_name=MYSQL_ROUTER_APP_NAME,
-        num_units=1,
-        resources=resources,
-        base="ubuntu@24.04",
+        MYSQL_ROUTER_APP_NAME,
+        *resource_args,
+        "--base=ubuntu@24.04",
+        "--num-units=1",
     )
 
     await ops_test.model.wait_for_idle(

--- a/kubernetes/tests/integration/integration/test_charm.py
+++ b/kubernetes/tests/integration/integration/test_charm.py
@@ -37,45 +37,56 @@ async def test_database_relation(ops_test: OpsTest, charm):
     """Test the database relation."""
     await ops_test.model.set_config(MODEL_CONFIG)
 
-    mysqlrouter_resources = {
-        "mysql-router-image": METADATA["resources"]["mysql-router-image"]["upstream-source"]
-    }
+    resource_args = [
+        f"--resource=mysql-router-image={METADATA['resources']['mysql-router-image']['upstream-source']}",
+    ]
 
     logger.info("Deploying mysql, mysqlrouter and application")
-    applications = await asyncio.gather(
-        ops_test.model.deploy(
+    await asyncio.gather(
+        ops_test.juju(
+            "deploy",
             MYSQL_APP_NAME,
-            channel="8.4/edge",
-            application_name=MYSQL_APP_NAME,
-            config={"profile": "testing"},
-            base="ubuntu@24.04",
-            num_units=3,
-            trust=True,  # Necessary after a6f1f01: Fix/endpoints as k8s services (#142)
+            MYSQL_APP_NAME,
+            "--channel=8.4/edge",
+            "--config=profile=testing",
+            "--base=ubuntu@24.04",
+            "--num-units=3",
+            "--trust",
         ),
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             charm,
-            application_name=MYSQL_ROUTER_APP_NAME,
-            base="ubuntu@24.04",
-            resources=mysqlrouter_resources,
-            num_units=1,
-            trust=True,
+            MYSQL_ROUTER_APP_NAME,
+            *resource_args,
+            "--base=ubuntu@24.04",
+            "--num-units=1",
+            "--trust",
         ),
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             APPLICATION_APP_NAME,
-            channel="latest/edge",
-            application_name=APPLICATION_APP_NAME,
-            base="ubuntu@24.04",
-            num_units=1,
+            APPLICATION_APP_NAME,
+            "--channel=latest/edge",
+            "--base=ubuntu@24.04",
+            "--num-units=1",
         ),
     )
 
-    mysql_app, application_app = applications[0], applications[2]
+    mysql_app = ops_test.model.applications[MYSQL_APP_NAME]
+    mysql_router_app = ops_test.model.applications[MYSQL_ROUTER_APP_NAME]
+    application_app = ops_test.model.applications[APPLICATION_APP_NAME]
 
     async with ops_test.fast_forward():
         logger.info("Waiting for mysqlrouter to be in BlockedStatus")
-        await ops_test.model.block_until(
-            lambda: ops_test.model.applications[MYSQL_ROUTER_APP_NAME].status == "blocked",
-            timeout=SLOW_TIMEOUT,
+        await asyncio.gather(
+            ops_test.model.block_until(
+                lambda: mysql_app.status == "active",
+                timeout=SLOW_TIMEOUT,
+            ),
+            ops_test.model.block_until(
+                lambda: mysql_router_app.status == "blocked",
+                timeout=SLOW_TIMEOUT,
+            ),
         )
 
         logger.info("Relating mysql, mysqlrouter and application")

--- a/kubernetes/tests/integration/integration/test_exporter.py
+++ b/kubernetes/tests/integration/integration/test_exporter.py
@@ -34,52 +34,55 @@ RETRY_TIMEOUT = 3 * 60
 @pytest.mark.abort_on_fail
 async def test_exporter_endpoint(ops_test: OpsTest, charm) -> None:
     """Test that exporter endpoint is functional."""
-    mysqlrouter_resources = {
-        "mysql-router-image": METADATA["resources"]["mysql-router-image"]["upstream-source"]
-    }
+    resource_args = [
+        f"--resource=mysql-router-image={METADATA['resources']['mysql-router-image']['upstream-source']}",
+    ]
 
     logger.info("Deploying all the applications")
-
-    applications = await asyncio.gather(
-        ops_test.model.deploy(
+    await asyncio.gather(
+        ops_test.juju(
+            "deploy",
             MYSQL_APP_NAME,
-            channel="8.4/edge",
-            application_name=MYSQL_APP_NAME,
-            config={"profile": "testing"},
-            base="ubuntu@24.04",
-            num_units=1,
-            trust=True,
+            MYSQL_APP_NAME,
+            "--channel=8.4/edge",
+            "--config=profile=testing",
+            "--base=ubuntu@24.04",
+            "--num-units=1",
+            "--trust",
         ),
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             charm,
-            application_name=MYSQL_ROUTER_APP_NAME,
-            base="ubuntu@24.04",
-            resources=mysqlrouter_resources,
-            num_units=1,
-            trust=True,
+            MYSQL_ROUTER_APP_NAME,
+            *resource_args,
+            "--base=ubuntu@24.04",
+            "--num-units=1",
+            "--trust",
         ),
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             APPLICATION_APP_NAME,
-            channel="latest/edge",
-            application_name=APPLICATION_APP_NAME,
-            base="ubuntu@24.04",
-            num_units=1,
+            APPLICATION_APP_NAME,
+            "--channel=latest/edge",
+            "--base=ubuntu@24.04",
+            "--num-units=1",
         ),
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             GRAFANA_AGENT_APP_NAME,
-            application_name=GRAFANA_AGENT_APP_NAME,
-            num_units=1,
-            base="ubuntu@22.04",
-            channel="1/stable",
+            GRAFANA_AGENT_APP_NAME,
+            "--channel=1/stable",
+            "--base=ubuntu@22.04",
+            "--num-units=1",
         ),
     )
 
-    [_, mysqlrouter_app, __, ___] = applications
+    mysqlrouter_app = ops_test.model.applications[MYSQL_ROUTER_APP_NAME]
 
     async with ops_test.fast_forward("60s"):
         logger.info("Waiting for mysqlrouter to be in BlockedStatus")
         await ops_test.model.block_until(
-            lambda: ops_test.model.applications[MYSQL_ROUTER_APP_NAME].status == "blocked",
+            lambda: mysqlrouter_app.status == "blocked",
             timeout=SLOW_TIMEOUT,
         )
 

--- a/kubernetes/tests/integration/integration/test_exporter_with_tls.py
+++ b/kubernetes/tests/integration/integration/test_exporter_with_tls.py
@@ -37,47 +37,50 @@ RETRY_TIMEOUT = 3 * 60
 @pytest.mark.abort_on_fail
 async def test_exporter_endpoint(ops_test: OpsTest, charm) -> None:
     """Test that the exporter endpoint works when related with TLS"""
-    mysqlrouter_resources = {
-        "mysql-router-image": METADATA["resources"]["mysql-router-image"]["upstream-source"]
-    }
+    resource_args = [
+        f"--resource=mysql-router-image={METADATA['resources']['mysql-router-image']['upstream-source']}",
+    ]
 
     logger.info("Deploying all the applications")
-
     await asyncio.gather(
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             MYSQL_APP_NAME,
-            channel="8.4/edge",
-            application_name=MYSQL_APP_NAME,
-            config={"profile": "testing"},
-            base="ubuntu@24.04",
+            MYSQL_APP_NAME,
+            "--channel=8.4/edge",
+            "--config=profile=testing",
+            "--base=ubuntu@24.04",
             # TODO: Check again when switching to 8.4/edge channel
             # MySQL Router 8.4 requires cluster quorum for R/W traffic,
             # because of the unreachable_quorum_allowed_traffic config option
             # (only observable upon process restart)
-            num_units=3,
-            trust=True,
+            "--num-units=3",
+            "--trust",
         ),
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             charm,
-            application_name=MYSQL_ROUTER_APP_NAME,
-            base="ubuntu@24.04",
-            resources=mysqlrouter_resources,
-            num_units=1,
-            trust=True,
+            MYSQL_ROUTER_APP_NAME,
+            *resource_args,
+            "--base=ubuntu@24.04",
+            "--num-units=1",
+            "--trust",
         ),
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             APPLICATION_APP_NAME,
-            channel="latest/edge",
-            application_name=APPLICATION_APP_NAME,
-            base="ubuntu@24.04",
-            num_units=1,
+            APPLICATION_APP_NAME,
+            "--channel=latest/edge",
+            "--base=ubuntu@24.04",
+            "--num-units=1",
         ),
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             GRAFANA_AGENT_APP_NAME,
-            application_name=GRAFANA_AGENT_APP_NAME,
-            num_units=1,
-            base="ubuntu@22.04",
-            channel="1/stable",
+            GRAFANA_AGENT_APP_NAME,
+            "--channel=1/stable",
+            "--base=ubuntu@22.04",
+            "--num-units=1",
         ),
     )
 
@@ -121,12 +124,13 @@ async def test_exporter_endpoint(ops_test: OpsTest, charm) -> None:
     )
 
     logger.info(f"Deploying {TLS_APP_NAME}")
-    await ops_test.model.deploy(
+    await ops_test.juju(
+        "deploy",
         TLS_APP_NAME,
-        application_name=TLS_APP_NAME,
-        channel="1/stable",
-        config={"ca-common-name": "Test CA"},
-        base="ubuntu@24.04",
+        TLS_APP_NAME,
+        "--channel=1/stable",
+        "--config=ca-common-name=Test CA",
+        "--base=ubuntu@24.04",
     )
 
     await ops_test.model.wait_for_idle([TLS_APP_NAME], status="active", timeout=SLOW_TIMEOUT)

--- a/kubernetes/tests/integration/integration/test_expose_external.py
+++ b/kubernetes/tests/integration/integration/test_expose_external.py
@@ -91,36 +91,39 @@ async def test_expose_external(ops_test, charm) -> None:
     """Test the expose-external config option."""
     await ops_test.model.set_config(MODEL_CONFIG)
 
-    mysql_router_resources = {
-        "mysql-router-image": METADATA["resources"]["mysql-router-image"]["upstream-source"]
-    }
+    resource_args = [
+        f"--resource=mysql-router-image={METADATA['resources']['mysql-router-image']['upstream-source']}",
+    ]
 
     logger.info("Deploying mysql-k8s, mysql-router-k8s and data-integrator")
     await asyncio.gather(
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             MYSQL_APP_NAME,
-            channel="8.4/edge",
-            application_name=MYSQL_APP_NAME,
-            config={"profile": "testing"},
-            base="ubuntu@24.04",
-            num_units=1,
-            trust=True,
+            MYSQL_APP_NAME,
+            "--channel=8.4/edge",
+            "--config=profile=testing",
+            "--base=ubuntu@24.04",
+            "--num-units=1",
+            "--trust",
         ),
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             charm,
-            application_name=MYSQL_ROUTER_APP_NAME,
-            base="ubuntu@24.04",
-            resources=mysql_router_resources,
-            num_units=1,
-            trust=True,
+            MYSQL_ROUTER_APP_NAME,
+            *resource_args,
+            "--base=ubuntu@24.04",
+            "--num-units=1",
+            "--trust",
         ),
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             DATA_INTEGRATOR,
-            channel="latest/edge",
-            application_name=DATA_INTEGRATOR,
-            base="ubuntu@24.04",
-            config={"database-name": TEST_DATABASE_NAME},
-            num_units=1,
+            DATA_INTEGRATOR,
+            "--channel=latest/edge",
+            "--base=ubuntu@24.04",
+            f"--config=database-name={TEST_DATABASE_NAME}",
+            "--num-units=1",
         ),
     )
 
@@ -179,11 +182,13 @@ async def test_expose_external_with_tls(ops_test: OpsTest) -> None:
     )
 
     logger.info("Deploying TLS operator")
-    await ops_test.model.deploy(
+    await ops_test.juju(
+        "deploy",
         TLS_APP_NAME,
-        channel="1/stable",
-        config={"ca-common-name": "Test CA"},
-        base="ubuntu@24.04",
+        TLS_APP_NAME,
+        "--channel=1/stable",
+        "--config=ca-common-name=Test CA",
+        "--base=ubuntu@24.04",
     )
     async with ops_test.fast_forward("60s"):
         await ops_test.model.wait_for_idle(

--- a/kubernetes/tests/integration/integration/test_log_rotation.py
+++ b/kubernetes/tests/integration/integration/test_log_rotation.py
@@ -39,39 +39,44 @@ async def test_log_rotation(ops_test: OpsTest, charm):
     """Test log rotation."""
     await ops_test.model.set_config(MODEL_CONFIG)
 
-    mysqlrouter_resources = {
-        "mysql-router-image": METADATA["resources"]["mysql-router-image"]["upstream-source"]
-    }
+    resource_args = [
+        f"--resource=mysql-router-image={METADATA['resources']['mysql-router-image']['upstream-source']}",
+    ]
 
     logger.info("Deploying mysql, mysqlrouter and application")
-    applications = await asyncio.gather(
-        ops_test.model.deploy(
+    await asyncio.gather(
+        ops_test.juju(
+            "deploy",
             MYSQL_APP_NAME,
-            channel="8.4/edge",
-            application_name=MYSQL_APP_NAME,
-            config={"profile": "testing"},
-            base="ubuntu@24.04",
-            num_units=3,
-            trust=True,  # Necessary after a6f1f01: Fix/endpoints as k8s services (#142)
+            MYSQL_APP_NAME,
+            "--channel=8.4/edge",
+            "--config=profile=testing",
+            "--base=ubuntu@24.04",
+            "--num-units=3",
+            "--trust",
         ),
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             charm,
-            application_name=MYSQL_ROUTER_APP_NAME,
-            base="ubuntu@24.04",
-            resources=mysqlrouter_resources,
-            num_units=1,
-            trust=True,
+            MYSQL_ROUTER_APP_NAME,
+            *resource_args,
+            "--base=ubuntu@24.04",
+            "--num-units=1",
+            "--trust",
         ),
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             APPLICATION_APP_NAME,
-            channel="latest/edge",
-            application_name=APPLICATION_APP_NAME,
-            base="ubuntu@24.04",
-            num_units=1,
+            APPLICATION_APP_NAME,
+            "--channel=latest/edge",
+            "--base=ubuntu@24.04",
+            "--num-units=1",
         ),
     )
 
-    mysql_app, mysql_router_app, application_app = applications
+    mysql_app = ops_test.model.applications[MYSQL_APP_NAME]
+    mysql_router_app = ops_test.model.applications[MYSQL_ROUTER_APP_NAME]
+    application_app = ops_test.model.applications[APPLICATION_APP_NAME]
 
     async with ops_test.fast_forward():
         logger.info("Waiting for mysqlrouter to be in BlockedStatus")

--- a/kubernetes/tests/integration/integration/test_tls.py
+++ b/kubernetes/tests/integration/integration/test_tls.py
@@ -33,49 +33,53 @@ RETRY_TIMEOUT = 2 * 60
 @pytest.mark.abort_on_fail
 async def test_deploy_and_relate(ops_test: OpsTest, charm) -> None:
     """Test encryption when backend database is using TLS."""
-    mysqlrouter_resources = {
-        "mysql-router-image": METADATA["resources"]["mysql-router-image"]["upstream-source"]
-    }
+    resource_args = [
+        f"--resource=mysql-router-image={METADATA['resources']['mysql-router-image']['upstream-source']}",
+    ]
 
     logger.info("Deploy and relate all applications")
     async with ops_test.fast_forward():
         # deploy mysql first
-        await ops_test.model.deploy(
+        await ops_test.juju(
+            "deploy",
             MYSQL_APP_NAME,
-            channel="8.4/edge",
-            application_name=MYSQL_APP_NAME,
-            config={"profile": "testing"},
-            base="ubuntu@24.04",
+            MYSQL_APP_NAME,
+            "--channel=8.4/edge",
+            "--config=profile=testing",
+            "--base=ubuntu@24.04",
             # TODO: Check again when switching to 8.4/edge channel
             # MySQL Router 8.4 requires cluster quorum for R/W traffic,
             # because of the unreachable_quorum_allowed_traffic config option
             # (only observable upon process restart)
-            num_units=3,
-            trust=True,
+            "--num-units=3",
+            "--trust",
         )
 
         # tls, test app and router
         await asyncio.gather(
-            ops_test.model.deploy(
+            ops_test.juju(
+                "deploy",
                 charm,
-                application_name=MYSQL_ROUTER_APP_NAME,
-                base="ubuntu@24.04",
-                resources=mysqlrouter_resources,
-                num_units=1,
-                trust=True,
+                MYSQL_ROUTER_APP_NAME,
+                *resource_args,
+                "--base=ubuntu@24.04",
+                "--num-units=1",
+                "--trust",
             ),
-            ops_test.model.deploy(
+            ops_test.juju(
+                "deploy",
                 TLS_APP_NAME,
-                application_name=TLS_APP_NAME,
-                channel="1/stable",
-                config={"ca-common-name": "Test CA"},
-                base="ubuntu@24.04",
+                TLS_APP_NAME,
+                "--channel=1/stable",
+                "--config=ca-common-name=Test CA",
+                "--base=ubuntu@24.04",
             ),
-            ops_test.model.deploy(
+            ops_test.juju(
+                "deploy",
                 TEST_APP_NAME,
-                application_name=TEST_APP_NAME,
-                channel="latest/edge",
-                base="ubuntu@24.04",
+                TEST_APP_NAME,
+                "--channel=latest/edge",
+                "--base=ubuntu@24.04",
             ),
         )
 

--- a/kubernetes/tests/integration/integration/test_upgrade.py
+++ b/kubernetes/tests/integration/integration/test_upgrade.py
@@ -36,7 +36,9 @@ MYSQL_ROUTER_APP_NAME = MYSQL_ROUTER_DEFAULT_APP_NAME
 APPLICATION_APP_NAME = APPLICATION_DEFAULT_APP_NAME
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
-RESOURCES = {"mysql-router-image": METADATA["resources"]["mysql-router-image"]["upstream-source"]}
+RESOURCE_ARGS = [
+    f"--resource=mysql-router-image={METADATA['resources']['mysql-router-image']['upstream-source']}",
+]
 
 
 @pytest.mark.abort_on_fail
@@ -45,28 +47,31 @@ async def test_deploy_edge(ops_test: OpsTest) -> None:
     logger.info("Deploying all applications")
 
     await asyncio.gather(
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             MYSQL_APP_NAME,
-            channel="8.4/edge",
-            application_name=MYSQL_APP_NAME,
-            config={"profile": "testing"},
-            base="ubuntu@24.04",
-            num_units=1,
-            trust=True,  # Necessary after a6f1f01: Fix/endpoints as k8s services (#142)
+            MYSQL_APP_NAME,
+            "--channel=8.4/edge",
+            "--config=profile=testing",
+            "--base=ubuntu@24.04",
+            "--num-units=1",
+            "--trust",
         ),
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             MYSQL_ROUTER_APP_NAME,
-            application_name=MYSQL_ROUTER_APP_NAME,
-            num_units=3,
-            channel="8.4/edge",
-            base="ubuntu@24.04",
+            MYSQL_ROUTER_APP_NAME,
+            "--channel=8.4/edge",
+            "--base=ubuntu@24.04",
+            "--num-units=3",
         ),
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             APPLICATION_APP_NAME,
-            channel="latest/edge",
-            application_name=APPLICATION_APP_NAME,
-            base="ubuntu@24.04",
-            num_units=1,
+            APPLICATION_APP_NAME,
+            "--channel=latest/edge",
+            "--base=ubuntu@24.04",
+            "--num-units=1",
         ),
     )
 
@@ -95,7 +100,7 @@ async def test_upgrade_from_edge(ops_test: OpsTest, charm) -> None:
     mysql_router_application = ops_test.model.applications[MYSQL_ROUTER_APP_NAME]
 
     logger.info("Refresh the charm")
-    await mysql_router_application.refresh(path=charm, resources=RESOURCES)
+    await ops_test.juju("refresh", MYSQL_ROUTER_APP_NAME, f"--path={charm}", *RESOURCE_ARGS)
 
     # sleep to ensure that active status from before re-refresh does not affect below check
     time.sleep(15)
@@ -171,7 +176,7 @@ async def test_fail_and_rollback(ops_test: OpsTest, charm, continuous_writes) ->
     create_invalid_upgrade_charm(fault_charm)
 
     logger.info("Refreshing mysql router with an invalid charm")
-    await mysql_router_application.refresh(path=fault_charm, resources=RESOURCES)
+    await ops_test.juju("refresh", MYSQL_ROUTER_APP_NAME, f"--path={fault_charm}", *RESOURCE_ARGS)
 
     # Highest to lowest unit number
     refresh_order = sorted(
@@ -192,7 +197,7 @@ async def test_fail_and_rollback(ops_test: OpsTest, charm, continuous_writes) ->
     await ensure_all_units_continuous_writes_incrementing(ops_test)
 
     logger.info("Re-refresh the charm")
-    await mysql_router_application.refresh(path=charm, resources=RESOURCES)
+    await ops_test.juju("refresh", MYSQL_ROUTER_APP_NAME, f"--path={charm}", *RESOURCE_ARGS)
 
     # sleep to ensure that active status from before re-refresh does not affect below check
     time.sleep(15)

--- a/machines/tests/integration/integration/test_architecture.py
+++ b/machines/tests/integration/integration/test_architecture.py
@@ -18,18 +18,19 @@ async def test_arm_charm_on_amd_host(ops_test: OpsTest, charm, ubuntu_base) -> N
     charm = charm.replace("amd64", "arm64")
 
     await asyncio.gather(
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             charm,
-            application_name=MYSQL_ROUTER_APP_NAME,
-            num_units=0,
-            base=ubuntu_base,
+            MYSQL_ROUTER_APP_NAME,
+            f"--base={ubuntu_base}",
         ),
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             MYSQL_TEST_APP_NAME,
-            application_name=MYSQL_TEST_APP_NAME,
-            num_units=1,
-            channel="latest/edge",
-            base=ubuntu_base,
+            MYSQL_TEST_APP_NAME,
+            "--channel=latest/edge",
+            f"--base={ubuntu_base}",
+            "--num-units=1",
         ),
     )
 
@@ -51,18 +52,19 @@ async def test_amd_charm_on_arm_host(ops_test: OpsTest, charm, ubuntu_base) -> N
     charm = charm.replace("arm64", "amd64")
 
     await asyncio.gather(
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             charm,
-            application_name=MYSQL_ROUTER_APP_NAME,
-            num_units=0,
-            base=ubuntu_base,
+            MYSQL_ROUTER_APP_NAME,
+            f"--base={ubuntu_base}",
         ),
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             MYSQL_TEST_APP_NAME,
-            application_name=MYSQL_TEST_APP_NAME,
-            num_units=1,
-            channel="latest/edge",
-            base=ubuntu_base,
+            MYSQL_TEST_APP_NAME,
+            "--channel=latest/edge",
+            f"--base={ubuntu_base}",
+            "--num-units=1",
         ),
     )
 

--- a/machines/tests/integration/integration/test_data_integrator.py
+++ b/machines/tests/integration/integration/test_data_integrator.py
@@ -37,35 +37,38 @@ async def test_external_connectivity_with_data_integrator(
     logger.info("Deploy and relate all applications")
     async with ops_test.fast_forward():
         # deploy mysql first
-        await ops_test.model.deploy(
+        await ops_test.juju(
+            "deploy",
             MYSQL_APP_NAME,
-            channel="8.4/edge",
-            config={"profile": "testing"},
-            num_units=1,
+            MYSQL_APP_NAME,
+            "--channel=8.4/edge",
+            "--config=profile=testing",
+            "--num-units=1",
         )
-        data_integrator_config = {"database-name": TEST_DATABASE}
 
         # tls, data-integrator and router
         await asyncio.gather(
-            ops_test.model.deploy(
+            ops_test.juju(
+                "deploy",
                 charm,
-                application_name=MYSQL_ROUTER_APP_NAME,
-                num_units=None,
-                base=ubuntu_base,
+                MYSQL_ROUTER_APP_NAME,
+                f"--base={ubuntu_base}",
             ),
-            ops_test.model.deploy(
+            ops_test.juju(
+                "deploy",
                 TLS_APP_NAME,
-                application_name=TLS_APP_NAME,
-                channel="1/stable",
-                config={"ca-common-name": "Test CA"},
-                base="ubuntu@24.04",
+                TLS_APP_NAME,
+                "--channel=1/stable",
+                "--config=ca-common-name=Test CA",
+                "--base=ubuntu@24.04",
             ),
-            ops_test.model.deploy(
+            ops_test.juju(
+                "deploy",
                 DATA_INTEGRATOR_APP_NAME,
-                application_name=DATA_INTEGRATOR_APP_NAME,
-                channel="latest/stable",
-                base=ubuntu_base,
-                config=data_integrator_config,
+                DATA_INTEGRATOR_APP_NAME,
+                "--channel=latest/stable",
+                f"--config=database-name={TEST_DATABASE}",
+                f"--base={ubuntu_base}",
             ),
         )
 

--- a/machines/tests/integration/integration/test_database.py
+++ b/machines/tests/integration/integration/test_database.py
@@ -32,29 +32,33 @@ async def test_database_relation(ops_test: OpsTest, charm, ubuntu_base) -> None:
     """Test the database relation."""
     # deploy mysqlrouter with num_units=None since it's a subordinate charm
     # and will be installed with the related consumer application
-    applications = await asyncio.gather(
-        ops_test.model.deploy(
+    await asyncio.gather(
+        ops_test.juju(
+            "deploy",
             MYSQL_APP_NAME,
-            channel="8.4/edge",
-            application_name=MYSQL_APP_NAME,
-            config={"profile": "testing"},
-            num_units=1,
+            MYSQL_APP_NAME,
+            "--channel=8.4/edge",
+            "--config=profile=testing",
+            "--num-units=1",
         ),
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             charm,
-            application_name=MYSQL_ROUTER_APP_NAME,
-            num_units=None,
+            MYSQL_ROUTER_APP_NAME,
         ),
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             APPLICATION_APP_NAME,
-            application_name=APPLICATION_APP_NAME,
-            num_units=1,
-            channel="latest/edge",
-            base=ubuntu_base,
+            APPLICATION_APP_NAME,
+            "--channel=latest/edge",
+            f"--base={ubuntu_base}",
+            "--num-units=1",
         ),
     )
 
-    [mysql_app, mysql_router_app, application_app] = applications
+    mysql_app = ops_test.model.applications[MYSQL_APP_NAME]
+    mysql_router_app = ops_test.model.applications[MYSQL_ROUTER_APP_NAME]
+    application_app = ops_test.model.applications[APPLICATION_APP_NAME]
 
     await ops_test.model.relate(
         f"{MYSQL_ROUTER_APP_NAME}:backend-database", f"{MYSQL_APP_NAME}:database"

--- a/machines/tests/integration/integration/test_exporter.py
+++ b/machines/tests/integration/integration/test_exporter.py
@@ -33,39 +33,42 @@ async def test_exporter_endpoint(ops_test: OpsTest, charm, ubuntu_base) -> None:
 
     # deploy mysqlrouter with num_units=None since it's a subordinate charm
     # and will be installed with the related consumer application
-    applications = await asyncio.gather(
-        ops_test.model.deploy(
+    await asyncio.gather(
+        ops_test.juju(
+            "deploy",
             MYSQL_APP_NAME,
-            channel="8.4/edge",
-            application_name=MYSQL_APP_NAME,
-            config={"profile": "testing"},
-            num_units=1,
+            MYSQL_APP_NAME,
+            "--channel=8.4/edge",
+            "--config=profile=testing",
+            "--num-units=1",
         ),
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             charm,
-            application_name=MYSQL_ROUTER_APP_NAME,
-            num_units=0,
-            base=ubuntu_base,
+            MYSQL_ROUTER_APP_NAME,
+            f"--base={ubuntu_base}",
         ),
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             APPLICATION_APP_NAME,
-            application_name=APPLICATION_APP_NAME,
-            num_units=1,
-            # MySQL Router and Grafana agent are subordinate -
-            # they will use the series of the principal charm
-            base=ubuntu_base,
-            channel="latest/edge",
+            APPLICATION_APP_NAME,
+            "--channel=latest/edge",
+            f"--base={ubuntu_base}",
+            "--num-units=1",
         ),
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             GRAFANA_AGENT_APP_NAME,
-            application_name=GRAFANA_AGENT_APP_NAME,
-            num_units=0,
-            channel="1/stable",
-            base=ubuntu_base,
+            GRAFANA_AGENT_APP_NAME,
+            "--channel=1/stable",
+            f"--base={ubuntu_base}",
         ),
     )
 
-    [mysql_app, mysql_router_app, mysql_test_app, grafana_agent_app] = applications
+    mysql_app = ops_test.model.applications[MYSQL_APP_NAME]
+    mysql_router_app = ops_test.model.applications[MYSQL_ROUTER_APP_NAME]
+    mysql_test_app = ops_test.model.applications[APPLICATION_APP_NAME]
+    grafana_agent_app = ops_test.model.applications[GRAFANA_AGENT_APP_NAME]
 
     logger.info("Relating mysqlrouter and grafana-agent with mysql-test-app")
 

--- a/machines/tests/integration/integration/test_exporter_with_tls.py
+++ b/machines/tests/integration/integration/test_exporter_with_tls.py
@@ -36,43 +36,46 @@ async def test_exporter_endpoint(ops_test: OpsTest, charm, ubuntu_base) -> None:
 
     # deploy mysqlrouter with num_units=None since it's a subordinate charm
     # and will be installed with the related consumer application
-    applications = await asyncio.gather(
-        ops_test.model.deploy(
+    await asyncio.gather(
+        ops_test.juju(
+            "deploy",
             MYSQL_APP_NAME,
-            channel="8.4/edge",
-            application_name=MYSQL_APP_NAME,
-            config={"profile": "testing"},
+            MYSQL_APP_NAME,
+            "--channel=8.4/edge",
+            "--config=profile=testing",
             # TODO: Check again when switching to 8.4/edge channel
             # MySQL Router 8.4 requires cluster quorum for R/W traffic,
             # because of the unreachable_quorum_allowed_traffic config option
             # (only observable upon process restart)
-            num_units=3,
+            "--num-units=3",
         ),
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             charm,
-            application_name=MYSQL_ROUTER_APP_NAME,
-            num_units=0,
-            base=ubuntu_base,
+            MYSQL_ROUTER_APP_NAME,
+            f"--base={ubuntu_base}",
         ),
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             APPLICATION_APP_NAME,
-            application_name=APPLICATION_APP_NAME,
-            num_units=1,
-            # MySQL Router and Grafana agent are subordinate -
-            # they will use the series of the principal charm
-            base=ubuntu_base,
-            channel="latest/edge",
+            APPLICATION_APP_NAME,
+            "--channel=latest/edge",
+            f"--base={ubuntu_base}",
+            "--num-units=1",
         ),
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             GRAFANA_AGENT_APP_NAME,
-            application_name=GRAFANA_AGENT_APP_NAME,
-            num_units=0,
-            channel="1/stable",
-            base=ubuntu_base,
+            GRAFANA_AGENT_APP_NAME,
+            "--channel=1/stable",
+            f"--base={ubuntu_base}",
         ),
     )
 
-    [mysql_app, mysql_router_app, mysql_test_app, grafana_agent_app] = applications
+    mysql_app = ops_test.model.applications[MYSQL_APP_NAME]
+    mysql_router_app = ops_test.model.applications[MYSQL_ROUTER_APP_NAME]
+    mysql_test_app = ops_test.model.applications[APPLICATION_APP_NAME]
+    grafana_agent_app = ops_test.model.applications[GRAFANA_AGENT_APP_NAME]
 
     logger.info("Relating mysqlrouter and grafana-agent with mysql-test-app")
 
@@ -129,12 +132,13 @@ async def test_exporter_endpoint(ops_test: OpsTest, charm, ubuntu_base) -> None:
     )
 
     logger.info(f"Deploying {TLS_APP_NAME}")
-    await ops_test.model.deploy(
+    await ops_test.juju(
+        "deploy",
         TLS_APP_NAME,
-        application_name=TLS_APP_NAME,
-        channel="1/stable",
-        config={"ca-common-name": "Test CA"},
-        base="ubuntu@24.04",
+        TLS_APP_NAME,
+        "--channel=1/stable",
+        "--config=ca-common-name=Test CA",
+        "--base=ubuntu@24.04",
     )
     await ops_test.model.wait_for_idle([TLS_APP_NAME], status="active", timeout=SLOW_TIMEOUT)
 

--- a/machines/tests/integration/integration/test_hacluster.py
+++ b/machines/tests/integration/integration/test_hacluster.py
@@ -87,28 +87,33 @@ async def test_external_connectivity_vip_with_hacluster(
     # speed up test by firing update-status more frequently (for hacluster)
     async with ops_test.fast_forward("60s"):
         # deploy data-integrator with mysqlrouter
-        _, _, data_integrator_application = await asyncio.gather(
-            ops_test.model.deploy(
+        await asyncio.gather(
+            ops_test.juju(
+                "deploy",
                 MYSQL_APP_NAME,
-                channel="8.4/edge",
-                config={"profile": "testing"},
-                num_units=1,
+                MYSQL_APP_NAME,
+                "--channel=8.4/edge",
+                "--config=profile=testing",
+                "--num-units=1",
             ),
-            ops_test.model.deploy(
+            ops_test.juju(
+                "deploy",
                 charm,
-                application_name=MYSQL_ROUTER_APP_NAME,
-                num_units=None,
-                base=ubuntu_base,
+                MYSQL_ROUTER_APP_NAME,
+                f"--base={ubuntu_base}",
             ),
-            ops_test.model.deploy(
+            ops_test.juju(
+                "deploy",
                 DATA_INTEGRATOR_APP_NAME,
-                application_name=DATA_INTEGRATOR_APP_NAME,
-                channel="latest/stable",
-                base=ubuntu_base,
-                config={"database-name": TEST_DATABASE},
-                num_units=4,
+                DATA_INTEGRATOR_APP_NAME,
+                "--channel=latest/stable",
+                f"--base={ubuntu_base}",
+                f"--config=database-name={TEST_DATABASE}",
+                "--num-units=4",
             ),
         )
+
+        data_integrator_application = ops_test.model.applications[DATA_INTEGRATOR_APP_NAME]
 
         await ops_test.model.relate(
             f"{MYSQL_ROUTER_APP_NAME}:backend-database", f"{MYSQL_APP_NAME}:database"
@@ -144,9 +149,10 @@ async def test_external_connectivity_vip_with_hacluster(
         assert hostname in data_integrator_ips, "Hostname is not a data-integrator"
 
         logger.info("Deploy and relate hacluster")
-        await ops_test.model.deploy(
+        await ops_test.juju(
+            "deploy",
             HA_CLUSTER_APP_NAME,
-            channel="2.4/edge",
+            "--channel=2.4/edge",
         )
 
         await ops_test.model.relate(
@@ -254,12 +260,13 @@ async def test_tls_along_with_ha_cluster(ops_test: OpsTest, ubuntu_base) -> None
     """Ensure that mysqlrouter is externally accessible with TLS integration."""
     logger.info("Deploying TLS")
     async with ops_test.fast_forward("60s"):
-        await ops_test.model.deploy(
+        await ops_test.juju(
+            "deploy",
             TLS_APP_NAME,
-            application_name=TLS_APP_NAME,
-            channel="1/stable",
-            config={"ca-common-name": "Test CA"},
-            base="ubuntu@24.04",
+            TLS_APP_NAME,
+            "--channel=1/stable",
+            "--config=ca-common-name=Test CA",
+            "--base=ubuntu@24.04",
         )
 
     logger.info("Ensure auto-generated TLS cert before relation with TLS")

--- a/machines/tests/integration/integration/test_log_rotation.py
+++ b/machines/tests/integration/integration/test_log_rotation.py
@@ -35,30 +35,33 @@ async def test_log_rotation(ops_test: OpsTest, charm, ubuntu_base) -> None:
 
     # deploy mysqlrouter with num_units=None since it's a subordinate charm
     # and will be installed with the related consumer application
-    applications = await asyncio.gather(
-        ops_test.model.deploy(
+    await asyncio.gather(
+        ops_test.juju(
+            "deploy",
             MYSQL_APP_NAME,
-            channel="8.4/edge",
-            application_name=MYSQL_APP_NAME,
-            config={"profile": "testing"},
-            num_units=1,
+            MYSQL_APP_NAME,
+            "--channel=8.4/edge",
+            "--config=profile=testing",
+            "--num-units=1",
         ),
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             charm,
-            application_name=MYSQL_ROUTER_APP_NAME,
-            num_units=None,
+            MYSQL_ROUTER_APP_NAME,
         ),
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             APPLICATION_APP_NAME,
-            application_name=APPLICATION_APP_NAME,
-            num_units=1,
-            # MySQL Router is subordinate—it will use the series of the principal charm
-            base=ubuntu_base,
-            channel="latest/edge",
+            APPLICATION_APP_NAME,
+            "--channel=latest/edge",
+            f"--base={ubuntu_base}",
+            "--num-units=1",
         ),
     )
 
-    mysql_app, mysql_router_app, application_app = applications
+    mysql_app = ops_test.model.applications[MYSQL_APP_NAME]
+    mysql_router_app = ops_test.model.applications[MYSQL_ROUTER_APP_NAME]
+    application_app = ops_test.model.applications[APPLICATION_APP_NAME]
     unit = application_app.units[0]
 
     logger.info("Relating mysqlrouter with mysql-test-app")

--- a/machines/tests/integration/integration/test_subordinate_charms.py
+++ b/machines/tests/integration/integration/test_subordinate_charms.py
@@ -19,32 +19,33 @@ LANDSCAPE_CLIENT_APP_NAME = "landscape-client"
 
 async def test_ubuntu_pro(ops_test, charm, ubuntu_base):
     await asyncio.gather(
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             MYSQL_APP_NAME,
-            channel="8.4/edge",
-            application_name=MYSQL_APP_NAME,
-            config={"profile": "testing"},
+            MYSQL_APP_NAME,
+            "--channel=8.4/edge",
+            "--config=profile=testing",
         ),
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             charm,
-            application_name=MYSQL_ROUTER_APP_NAME,
-            # deploy mysqlrouter with num_units=None since it's a subordinate charm
-            num_units=None,
-            base=ubuntu_base,
+            MYSQL_ROUTER_APP_NAME,
+            f"--base={ubuntu_base}",
         ),
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             APPLICATION_APP_NAME,
-            application_name=APPLICATION_APP_NAME,
-            channel="latest/edge",
-            # MySQL Router is subordinate—it will use the series of the principal charm
-            base=ubuntu_base,
+            APPLICATION_APP_NAME,
+            "--channel=latest/edge",
+            f"--base={ubuntu_base}",
         ),
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             UBUNTU_PRO_APP_NAME,
-            application_name=UBUNTU_PRO_APP_NAME,
-            channel="latest/edge",
-            config={"token": os.environ["UBUNTU_PRO_TOKEN"]},
-            base=ubuntu_base,
+            UBUNTU_PRO_APP_NAME,
+            "--channel=latest/edge",
+            f"--config=token={os.environ['UBUNTU_PRO_TOKEN']}",
+            f"--base={ubuntu_base}",
         ),
     )
     await ops_test.model.relate(
@@ -70,16 +71,15 @@ async def test_ubuntu_pro(ops_test, charm, ubuntu_base):
 
 
 async def test_landscape_client(ops_test, ubuntu_base):
-    await ops_test.model.deploy(
+    await ops_test.juju(
+        "deploy",
         LANDSCAPE_CLIENT_APP_NAME,
-        application_name=LANDSCAPE_CLIENT_APP_NAME,
-        channel="latest/edge",
-        config={
-            "account-name": os.environ["LANDSCAPE_ACCOUNT_NAME"],
-            "registration-key": os.environ["LANDSCAPE_REGISTRATION_KEY"],
-            "ppa": "ppa:landscape/self-hosted-beta",
-        },
-        base=ubuntu_base,
+        LANDSCAPE_CLIENT_APP_NAME,
+        "--channel=latest/edge",
+        "--config=ppa=ppa:landscape/self-hosted-beta",
+        f"--config=account-name={os.environ['LANDSCAPE_ACCOUNT_NAME']}",
+        f"--config=registration-key={os.environ['LANDSCAPE_REGISTRATION_KEY']}",
+        f"--base={ubuntu_base}",
     )
     await ops_test.model.relate(APPLICATION_APP_NAME, LANDSCAPE_CLIENT_APP_NAME)
     async with ops_test.fast_forward("60s"):

--- a/machines/tests/integration/integration/test_tls.py
+++ b/machines/tests/integration/integration/test_tls.py
@@ -32,38 +32,41 @@ async def test_build_deploy_and_relate(ops_test: OpsTest, charm, ubuntu_base) ->
     logger.info("Deploy and relate all applications")
     async with ops_test.fast_forward():
         # deploy mysql first
-        await ops_test.model.deploy(
+        await ops_test.juju(
+            "deploy",
             MYSQL_APP_NAME,
-            channel="8.4/edge",
-            application_name=MYSQL_APP_NAME,
-            config={"profile": "testing"},
+            MYSQL_APP_NAME,
+            "--channel=8.4/edge",
+            "--config=profile=testing",
             # TODO: Check again when switching to 8.4/edge channel
             # MySQL Router 8.4 requires cluster quorum for R/W traffic,
             # because of the unreachable_quorum_allowed_traffic config option
             # (only observable upon process restart)
-            num_units=3,
+            "--num-units=3",
         )
 
         # tls, test app and router
         await asyncio.gather(
-            ops_test.model.deploy(
+            ops_test.juju(
+                "deploy",
                 charm,
-                application_name=MYSQL_ROUTER_APP_NAME,
-                num_units=None,
-                base=ubuntu_base,
+                MYSQL_ROUTER_APP_NAME,
+                f"--base={ubuntu_base}",
             ),
-            ops_test.model.deploy(
+            ops_test.juju(
+                "deploy",
                 TLS_APP_NAME,
-                application_name=TLS_APP_NAME,
-                channel="1/stable",
-                config={"ca-common-name": "Test CA"},
-                base="ubuntu@24.04",
+                TLS_APP_NAME,
+                "--channel=1/stable",
+                "--config=ca-common-name=Test CA",
+                "--base=ubuntu@24.04",
             ),
-            ops_test.model.deploy(
+            ops_test.juju(
+                "deploy",
                 TEST_APP_NAME,
-                application_name=TEST_APP_NAME,
-                channel="latest/edge",
-                base=ubuntu_base,
+                TEST_APP_NAME,
+                "--channel=latest/edge",
+                f"--base={ubuntu_base}",
             ),
         )
 

--- a/machines/tests/integration/integration/test_upgrade.py
+++ b/machines/tests/integration/integration/test_upgrade.py
@@ -38,26 +38,29 @@ async def test_deploy_edge(ops_test: OpsTest, ubuntu_base) -> None:
     """Simple test to ensure that mysql, mysqlrouter and application charms deploy."""
     logger.info("Deploying all applications")
     await asyncio.gather(
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             MYSQL_APP_NAME,
-            application_name=MYSQL_APP_NAME,
-            num_units=1,
-            channel="8.4/edge",
-            config={"profile": "testing"},
+            MYSQL_APP_NAME,
+            "--channel=8.4/edge",
+            "--config=profile=testing",
+            "--num-units=1",
         ),
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             MYSQL_ROUTER_APP_NAME,
-            application_name=MYSQL_ROUTER_APP_NAME,
-            num_units=1,
-            channel="8.4/edge",
-            base=ubuntu_base,
+            MYSQL_ROUTER_APP_NAME,
+            "--channel=8.4/edge",
+            f"--base={ubuntu_base}",
+            "--num-units=1",
         ),
-        ops_test.model.deploy(
+        ops_test.juju(
+            "deploy",
             TEST_APP_NAME,
-            application_name=TEST_APP_NAME,
-            num_units=3,
-            channel="latest/edge",
-            base=ubuntu_base,
+            TEST_APP_NAME,
+            "--channel=latest/edge",
+            f"--base={ubuntu_base}",
+            "--num-units=3",
         ),
     )
 
@@ -90,7 +93,7 @@ async def test_upgrade_from_edge(ops_test: OpsTest, charm, continuous_writes) ->
     create_valid_upgrade_charm(temporary_charm)
 
     logger.info("Refresh the charm")
-    await mysql_router_application.refresh(path=temporary_charm)
+    await ops_test.juju("refresh", MYSQL_ROUTER_APP_NAME, f"--path={temporary_charm}")
 
     # sleep to ensure that active status from before re-refresh does not affect below check
     time.sleep(15)
@@ -177,7 +180,7 @@ async def test_fail_and_rollback(ops_test: OpsTest, charm, continuous_writes) ->
     create_invalid_upgrade_charm(fault_charm)
 
     logger.info("Refreshing mysql router with an invalid charm")
-    await mysql_router_application.refresh(path=fault_charm)
+    await ops_test.juju("refresh", MYSQL_ROUTER_APP_NAME, f"--path={fault_charm}")
 
     logger.info("Wait for upgrade to fail")
     await ops_test.model.block_until(
@@ -191,7 +194,7 @@ async def test_fail_and_rollback(ops_test: OpsTest, charm, continuous_writes) ->
     await ensure_all_units_continuous_writes_incrementing(ops_test)
 
     logger.info("Re-refresh the charm")
-    await mysql_router_application.refresh(path="./upgrade.charm")
+    await ops_test.juju("refresh", MYSQL_ROUTER_APP_NAME, "--path=./upgrade.charm")
 
     logger.info("Wait for the charm to be rolled back")
     await ops_test.model.wait_for_idle(


### PR DESCRIPTION
This PR migrates the integration tests to use Juju CLI for deployment and refresh operations. This is a mandatory requirement for building the MySQL Router 8.4 operator for Ubuntu 26.04, as version 3.6.1.3 of the `juju` package (latest) has a couple of blocking limitations:

- The Ubuntu 26.04 base has not been added to the list of supported bases, and it is unlikely to be (see [PR](https://github.com/juju/python-libjuju/pull/1281)).
- The base constraints are not properly forwarded to the store, invalidating the use of `--force` (see [issue](https://github.com/juju/python-libjuju/issues/1273)).

---

Unblocks PR https://github.com/canonical/mysql-router-operators/pull/148
