### PR TITLE
[MISC] (8.4/edge) Fix packaging again

### DIFF
--- a/kubernetes/pyproject.toml
+++ b/kubernetes/pyproject.toml
@@ -49,7 +49,7 @@ build-refresh-version = [
 
 [tool.poetry]
 package-mode = false
-requires-poetry = ">=2.0.0"
+requires-poetry = ">=2.2.0"
 
 [tool.poetry.dependencies]
 python = "^3.12"

--- a/kubernetes/pyproject.toml
+++ b/kubernetes/pyproject.toml
@@ -1,11 +1,6 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-[project]
-name = "mysql-router-k8s-operator"
-version = "0.0.1"
-dynamic = ["dependencies", "requires-python"]
-
 [dependency-groups]
 charm-libs = [
     # data_platform_libs/v0/data_interfaces.py

--- a/machines/pyproject.toml
+++ b/machines/pyproject.toml
@@ -1,11 +1,6 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-[project]
-name = "mysql-router-operator"
-version = "0.0.1"
-dynamic = ["dependencies", "requires-python"]
-
 [dependency-groups]
 charm-libs = [
     # data_platform_libs/v0/data_interfaces.py


### PR DESCRIPTION
## Issue

Same rationale as https://github.com/canonical/mysql-operators/pull/75

#77 adopted packaging standards, but adding a `[project]` table was overreach, because it made tools believe that it could be packaged. It cannot (these are applications, generating sdist and bdist from here doesn't make sense).

## Solution
