### PR TITLE
[DPE-9970] 8.4 - Enable build cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,7 +80,6 @@ jobs:
     name: Build charm | ${{ matrix.path }}
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v49
     with:
-      cache: false  # TODO: revert when PR merged + charmcraft-hub cache built
       path-to-charm-directory: ${{ matrix.path }}
     permissions:
       actions: read

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -21,7 +21,6 @@ jobs:
           - machines
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v49
     with:
-      cache: false  # TODO: revert when PR merged + charmcraft-hub cache built
       path-to-charm-directory: ${{ matrix.path }}
     permissions:
       actions: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,6 @@ jobs:
           - machines
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v49
     with:
-      cache: false  # TODO: revert when PR merged + charmcraft-hub cache built
       path-to-charm-directory: ${{ matrix.path }}
     permissions:
       actions: read

--- a/kubernetes/tests/spread/integration/test_upgrade.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_upgrade.py/task.yaml
@@ -2,8 +2,6 @@ summary: test_upgrade.py
 environment:
   TEST_MODULE: test_upgrade.py
 execute: |
-  # TODO: Uncomment when mysql-router-k8s 26.04 gets released into 8.4/edge
-  # tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
-  exit 0
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_upgrade.py/task.yaml
+++ b/machines/tests/spread/integration/test_upgrade.py/task.yaml
@@ -2,8 +2,6 @@ summary: test_upgrade.py
 environment:
   TEST_MODULE: test_upgrade.py
 execute: |
-  # TODO: Uncomment when mysql-router 26.04 gets released into 8.4/edge
-  # tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
-  exit 0
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results


### PR DESCRIPTION
This PR re-enables the build cache after migrating to the Ubuntu 26.04 base, in addition to the upgrade tests.

Can only be merged when [charmcraftcache-hub](https://github.com/canonical/charmcraftcache-hub) builds it for Ubuntu 26.04.
