### PR TITLE
[DPE-7684] (dpe) Avoid crashing on teardown if credentials are revoked

### DIFF
--- a/common/common/relations/database_provides.py
+++ b/common/common/relations/database_provides.py
@@ -7,6 +7,7 @@ import logging
 import typing
 
 import ops
+from mysql_shell.executors.errors import ExecutionError
 
 from .. import mysql_shell, status_exception
 from .._charm_libs.charms.data_platform_libs.v0 import data_interfaces
@@ -277,7 +278,14 @@ class RelationEndpoint:
                 )
         for relation in self._shared_users:
             if relation not in requested_users:
-                relation.delete_user(shell=shell)
+                try:
+                    relation.delete_user(shell=shell)
+                except ExecutionError:
+                    logger.warning(
+                        "Failed to delete user (credentials may have been revoked by MySQL). "
+                        "Cleaning up databag only"
+                    )
+                    relation.delete_databag()
         logger.debug(
             f"Reconciled users {event=}, {router_read_write_endpoints=}, {router_read_only_endpoints=}"
         )

--- a/common/common/workload.py
+++ b/common/common/workload.py
@@ -15,6 +15,7 @@ import charm_refresh
 import ops
 import requests
 import tenacity
+from mysql_shell.executors.errors import ExecutionError
 
 from . import container, mysql_shell, server_exceptions
 
@@ -400,9 +401,20 @@ class RunningWorkload(Workload):
 
         # If the router is not in the cluster set, disable to restart it
         # This can happen when the server is scaled to zero and back
+        try:
+            router_not_in_cluster_set = (
+                self._router_id not in self.shell.get_routers_in_cluster_set()
+            )
+        except ExecutionError:
+            # Credentials may have been revoked by MySQL during teardown
+            logger.warning(
+                "Failed to query cluster set routers (credentials may have been revoked). "
+                "Disabling router"
+            )
+            router_not_in_cluster_set = True
         if any((
             is_charm_exposed == socket_file_exists,
-            self._router_id not in self.shell.get_routers_in_cluster_set()
+            router_not_in_cluster_set,
         )):
             self._disable_router()
 

--- a/common/common/workload.py
+++ b/common/common/workload.py
@@ -402,19 +402,18 @@ class RunningWorkload(Workload):
         # If the router is not in the cluster set, disable to restart it
         # This can happen when the server is scaled to zero and back
         try:
-            router_not_in_cluster_set = (
-                self._router_id not in self.shell.get_routers_in_cluster_set()
-            )
+            cluster_set_routers = self.shell.get_routers_in_cluster_set()
         except ExecutionError:
             # Credentials may have been revoked by MySQL during teardown
+            cluster_set_routers = []
             logger.warning(
                 "Failed to query cluster set routers (credentials may have been revoked). "
                 "Disabling router"
             )
-            router_not_in_cluster_set = True
+
         if any((
             is_charm_exposed == socket_file_exists,
-            router_not_in_cluster_set,
+            self._router_id not in cluster_set_routers,
         )):
             self._disable_router()
 


### PR DESCRIPTION
## Issue

See issue #24

## Solution

On teardown, if credentials are revoked, avoid breaking the charm
