### PR TITLE
[MISC] 8.0 - Enable shared-db integration test

### DIFF
--- a/machines/tests/integration/integration/test_shared_db.py
+++ b/machines/tests/integration/integration/test_shared_db.py
@@ -15,7 +15,7 @@ from ..helpers_new import (
     wait_for_apps_status,
 )
 
-KEYSTONE_APP_NAME = "keystone"
+MASAKARI_APP_NAME = "masakari"
 MYSQL_ROUTER_APP_NAME = "mysql-router"
 MYSQL_SERVER_APP_NAME = "mysql"
 
@@ -38,8 +38,8 @@ def test_shared_db(juju: Juju, charm: str, ubuntu_base: str):
         num_units=1,
     )
     juju.deploy(
-        charm=KEYSTONE_APP_NAME,
-        app=KEYSTONE_APP_NAME,
+        charm=MASAKARI_APP_NAME,
+        app=MASAKARI_APP_NAME,
         base=ubuntu_base,
         channel="latest/edge",
         num_units=1,
@@ -51,13 +51,17 @@ def test_shared_db(juju: Juju, charm: str, ubuntu_base: str):
         f"{MYSQL_ROUTER_APP_NAME}:backend-database",
     )
     juju.integrate(
-        f"{KEYSTONE_APP_NAME}:shared-db",
+        f"{MASAKARI_APP_NAME}:shared-db",
         f"{MYSQL_ROUTER_APP_NAME}:shared-db",
     )
 
     logging.info("Wait for applications to become active")
     juju.wait(
-        ready=wait_for_apps_status(jubilant_backports.all_active),
+        ready=wait_for_apps_status(
+            jubilant_backports.all_active,
+            MYSQL_SERVER_APP_NAME,
+            MYSQL_ROUTER_APP_NAME,
+        ),
         timeout=20 * MINUTE_SECS,
         delay=5.0,
     )
@@ -65,11 +69,11 @@ def test_shared_db(juju: Juju, charm: str, ubuntu_base: str):
     mysql_leader = get_app_leader(juju, MYSQL_SERVER_APP_NAME)
     mysql_creds = get_mysql_server_credentials(juju, mysql_leader, "serverconfig")
 
-    tables = execute_queries_against_unit(
+    databases = execute_queries_against_unit(
         username=mysql_creds["username"],
         password=mysql_creds["password"],
         host=get_unit_address(juju, MYSQL_SERVER_APP_NAME, mysql_leader),
         port=3306,
-        queries=["SHOW TABLES IN 'keystone';"],
+        queries=["SHOW DATABASES;"],
     )
-    assert len(tables) > 0
+    assert "masakari" in databases

--- a/machines/tests/spread/integration/test_shared_db.py/task.yaml
+++ b/machines/tests/spread/integration/test_shared_db.py/task.yaml
@@ -2,8 +2,6 @@ summary: test_shared_db.py
 environment:
   TEST_MODULE: test_shared_db.py
 execute: |
-  # Re-enable when bug resolved: https://bugs.launchpad.net/charm-keystone/+bug/1990243
-  # tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
-  exit 0
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results


### PR DESCRIPTION
This PR re-enables the shared-db integration test by using the `masakari` charm instead of the broken `keystone` one