### PR TITLE
[DPE-10198] 8.4 - Expose connection-sharing config

### DIFF
--- a/common/common/workload.py
+++ b/common/common/workload.py
@@ -280,6 +280,10 @@ class RunningWorkload(Workload):
                 "routing:bootstrap_rw.connection_sharing=1",
                 "--conf-set-option",
                 "routing:bootstrap_ro.connection_sharing=1",
+                "--conf-set-option",
+                "connection_pool.idle_timeout=60",
+                "--conf-set-option",
+                "connection_pool.max_idle_server_connections=1000",
             ])
         return command
 
@@ -352,7 +356,7 @@ class RunningWorkload(Workload):
         if not self._container.router_config_file.exists():
             return False
         return self._parse_connection_sharing_from_config(
-            self._container.router_config_file.read_text()
+            self._container.router_config_file.read_text(),
         )
 
     @property
@@ -361,7 +365,9 @@ class RunningWorkload(Workload):
 
         During bootstrap, MySQL Router creates a config file which includes a generated username.
         """
-        return self._parse_username_from_config(self._container.router_config_file.read_text())
+        return self._parse_username_from_config(
+            self._container.router_config_file.read_text(),
+        )
 
     def _restart(self, *, event, tls: bool) -> None:
         """Restart MySQL Router to enable or disable TLS."""
@@ -445,14 +451,14 @@ class RunningWorkload(Workload):
 
         # Check if connection sharing config has changed
         connection_sharing_config = bool(self._charm.config.get("connection-sharing"))
-        connection_sharing_changed = (
-            self._container.mysql_router_service_enabled
-            and connection_sharing_config != self._router_connection_sharing_enabled
-        )
+        connection_sharing_changed = all((
+            self._container.mysql_router_service_enabled,
+            self._router_connection_sharing_enabled != connection_sharing_config,
+        ))
         if connection_sharing_changed:
             logger.info(
-                f"Connection sharing config changed to {connection_sharing_config}, "
-                "rebootstrapping router"
+                f"Connection sharing config changed to {connection_sharing_config}. "
+                "Restarting router"
             )
 
         # If the router is not in the cluster set, disable to restart it

--- a/common/common/workload.py
+++ b/common/common/workload.py
@@ -252,7 +252,7 @@ class RunningWorkload(Workload):
     def _get_bootstrap_command(
         self, *, event, connection_info: "database_requires.ConnectionInformation"
     ) -> list[str]:
-        return [
+        command = [
             "--bootstrap",
             connection_info.username
             + ":"
@@ -273,6 +273,15 @@ class RunningWorkload(Workload):
             "--conf-set-option",
             "metadata_cache:bootstrap.ttl=5",
         ]
+        # Add connection sharing options if enabled
+        if self._charm.config.get("connection-sharing"):
+            command.extend([
+                "--conf-set-option",
+                "routing:bootstrap_rw.connection_sharing=1",
+                "--conf-set-option",
+                "routing:bootstrap_ro.connection_sharing=1",
+            ])
+        return command
 
     def _bootstrap_router(self, *, event, tls: bool) -> None:
         """Bootstrap MySQL Router."""
@@ -325,6 +334,26 @@ class RunningWorkload(Workload):
         config = configparser.ConfigParser()
         config.read_string(config_file_text)
         return config["metadata_cache:bootstrap"]["user"]
+
+    @staticmethod
+    def _parse_connection_sharing_from_config(config_file_text: str) -> bool:
+        """Check if connection sharing is enabled in the router config file."""
+        config = configparser.ConfigParser()
+        config.read_string(config_file_text)
+        # Check if connection_sharing is set to 1 in routing:bootstrap_rw section
+        try:
+            return config.get("routing:bootstrap_rw", "connection_sharing") == "1"
+        except (configparser.NoSectionError, configparser.NoOptionError):
+            return False
+
+    @property
+    def _router_connection_sharing_enabled(self) -> bool:
+        """Read connection sharing state from MySQL Router config file."""
+        if not self._container.router_config_file.exists():
+            return False
+        return self._parse_connection_sharing_from_config(
+            self._container.router_config_file.read_text()
+        )
 
     @property
     def _router_username(self) -> str:
@@ -414,6 +443,18 @@ class RunningWorkload(Workload):
                 "`key`, `certificate`, and `certificate_authority` arguments required when tls=True"
             )
 
+        # Check if connection sharing config has changed
+        connection_sharing_config = bool(self._charm.config.get("connection-sharing"))
+        connection_sharing_changed = (
+            self._container.mysql_router_service_enabled
+            and connection_sharing_config != self._router_connection_sharing_enabled
+        )
+        if connection_sharing_changed:
+            logger.info(
+                f"Connection sharing config changed to {connection_sharing_config}, "
+                "rebootstrapping router"
+            )
+
         # If the router is not in the cluster set, disable to restart it
         # This can happen when the server is scaled to zero and back
         try:
@@ -433,6 +474,7 @@ class RunningWorkload(Workload):
         if any((
             self._router_running_correctly(event) is False,
             self._router_id not in cluster_set_routers,
+            connection_sharing_changed,
         )):
             self._disable_router()
 

--- a/common/common/workload.py
+++ b/common/common/workload.py
@@ -344,7 +344,6 @@ class RunningWorkload(Workload):
         """Check if connection sharing is enabled in the router config file."""
         config = configparser.ConfigParser()
         config.read_string(config_file_text)
-        # Check if connection_sharing is set to 1 in routing:bootstrap_rw section
         try:
             return config.get("routing:bootstrap_rw", "connection_sharing") == "1"
         except (configparser.NoSectionError, configparser.NoOptionError):
@@ -458,7 +457,7 @@ class RunningWorkload(Workload):
         if connection_sharing_changed:
             logger.info(
                 f"Connection sharing config changed to {connection_sharing_config}. "
-                "Restarting router"
+                "Bootstrapping router"
             )
 
         # If the router is not in the cluster set, disable to restart it

--- a/kubernetes/config.yaml
+++ b/kubernetes/config.yaml
@@ -2,6 +2,23 @@
 # See LICENSE file for licensing details.
 
 options:
+  connection-sharing:
+    description: |
+      Enable MySQL Router connection pooling and sharing.
+
+      When enabled, MySQL Router pools server connections and shares them between
+      client connections. This reduces the number of connections to the MySQL server
+      and frees resources bound to idle connections.
+
+      Note: Connection sharing has some limitations - certain SQL features like
+      GET DIAGNOSTICS, LAST_INSERT_ID(), SQL_CALC_FOUND_ROWS, GET_LOCK(), user
+      variables, temporary tables, and prepared statements may not work as expected
+      or will prevent connection pooling until the connection is reset.
+
+      See https://dev.mysql.com/doc/mysql-router/8.0/en/mysql-router-general-features-connection-sharing.html
+    type: boolean
+    default: false
+
   expose-external:
     description: |
       String to determine how to expose the MySQLRouter externally from the Kubernetes cluster.

--- a/kubernetes/config.yaml
+++ b/kubernetes/config.yaml
@@ -15,7 +15,7 @@ options:
       variables, temporary tables, and prepared statements may not work as expected
       or will prevent connection pooling until the connection is reset.
 
-      See https://dev.mysql.com/doc/mysql-router/8.0/en/mysql-router-general-features-connection-sharing.html
+      See https://dev.mysql.com/doc/mysql-router/8.4/en/mysql-router-general-features-connection-sharing.html
     type: boolean
     default: false
 

--- a/kubernetes/tests/integration/helpers.py
+++ b/kubernetes/tests/integration/helpers.py
@@ -16,18 +16,20 @@ from .connector import MySQLConnector
 
 
 def execute_queries_against_unit(
-    unit_address: str,
     username: str,
     password: str,
+    host: str,
+    port: int,
     queries: list[str],
     commit: bool = False,
 ) -> list:
     """Execute given MySQL queries on a unit.
 
     Args:
-        unit_address: The public IP address of the unit to execute the queries on
         username: The MySQL username
         password: The MySQL password
+        host: The host to connect to in order to execute queries
+        port: The port to connect to in order to execute queries
         queries: A list of queries to execute
         commit: A keyword arg indicating whether there are any writes queries
 
@@ -35,7 +37,8 @@ def execute_queries_against_unit(
         A list of rows that were potentially queried
     """
     connection = mysql.connector.connect(
-        host=unit_address,
+        host=host,
+        port=port,
         user=username,
         password=password,
     )

--- a/kubernetes/tests/integration/helpers_new.py
+++ b/kubernetes/tests/integration/helpers_new.py
@@ -185,10 +185,11 @@ def get_mysql_max_written_value(juju: Juju, app_name: str, unit_name: str) -> in
     credentials = get_mysql_server_credentials(juju, unit_name, "charmed-operator")
 
     output = execute_queries_against_unit(
-        get_unit_address(juju, app_name, unit_name),
-        credentials["username"],
-        credentials["password"],
-        ["SELECT MAX(number) FROM `continuous_writes`.`data`;"],
+        username=credentials["username"],
+        password=credentials["password"],
+        host=get_unit_address(juju, app_name, unit_name),
+        port=3306,
+        queries=["SELECT MAX(number) FROM `continuous_writes`.`data`;"],
     )
     return output[0]
 
@@ -264,10 +265,11 @@ def verify_mysql_test_data(juju: Juju, app_name: str, table_name: str, value: st
     ):
         with attempt:
             output = execute_queries_against_unit(
-                get_unit_address(juju, app_name, mysql_app_leader),
-                credentials["username"],
-                credentials["password"],
-                select_queries,
+                username=credentials["username"],
+                password=credentials["password"],
+                host=get_unit_address(juju, app_name, mysql_app_leader),
+                port=3306,
+                queries=select_queries,
             )
             assert output[0] == value
 

--- a/kubernetes/tests/integration/integration/test_conn_sharing.py
+++ b/kubernetes/tests/integration/integration/test_conn_sharing.py
@@ -1,0 +1,148 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+import time
+
+import jubilant
+import mysql.connector
+from jubilant import Juju
+
+from ..helpers_new import (
+    METADATA,
+    MINUTE_SECS,
+    get_app_leader,
+    get_mysql_server_credentials,
+    get_unit_address,
+    wait_for_apps_status,
+)
+
+MYSQL_ROUTER_APP_NAME = "mysql-router-k8s"
+MYSQL_SERVER_APP_NAME = "mysql-k8s"
+MYSQL_TEST_APP_NAME = "mysql-test-app"
+
+
+def test_deploy_and_relate(juju: Juju, charm: str) -> None:
+    """Test the database relation."""
+    router_resources = {
+        "mysql-router-image": METADATA["resources"]["mysql-router-image"]["upstream-source"]
+    }
+
+    logging.info("Deploying all the applications")
+    juju.deploy(
+        charm=MYSQL_SERVER_APP_NAME,
+        app=MYSQL_SERVER_APP_NAME,
+        base="ubuntu@26.04",
+        channel="8.4/edge",
+        config={"profile": "testing"},
+        # MySQL Router 8.4 requires cluster quorum for R/W traffic,
+        # because of the unreachable_quorum_allowed_traffic config option
+        # (only observable upon process restart)
+        num_units=3,
+        trust=True,
+    )
+    juju.deploy(
+        charm=charm,
+        app=MYSQL_ROUTER_APP_NAME,
+        base="ubuntu@26.04",
+        resources=router_resources,
+        num_units=1,
+        trust=True,
+    )
+    juju.deploy(
+        charm=MYSQL_TEST_APP_NAME,
+        app=MYSQL_TEST_APP_NAME,
+        base="ubuntu@26.04",
+        channel="latest/edge",
+        num_units=1,
+    )
+
+    logging.info("Relating the applications")
+    juju.integrate(
+        f"{MYSQL_SERVER_APP_NAME}:database",
+        f"{MYSQL_ROUTER_APP_NAME}:backend-database",
+    )
+    juju.integrate(
+        f"{MYSQL_TEST_APP_NAME}:database",
+        f"{MYSQL_ROUTER_APP_NAME}:database",
+    )
+
+    logging.info("Wait for applications to become active")
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active),
+        timeout=20 * MINUTE_SECS,
+        delay=5.0,
+    )
+
+
+def test_connection_sharing_disabled(juju: Juju) -> None:
+    """Test connection sharing disabled mode."""
+    juju.config(
+        app=MYSQL_ROUTER_APP_NAME,
+        values={"connection-sharing": "false"},
+    )
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, MYSQL_ROUTER_APP_NAME),
+        timeout=10 * MINUTE_SECS,
+    )
+
+    attempts = 10
+    conn_ids = fetch_connection_ids(juju, attempts)
+    assert len(conn_ids) == attempts
+
+
+def test_connection_sharing_enabled(juju: Juju) -> None:
+    """Test connection sharing enabled mode."""
+    juju.config(
+        app=MYSQL_ROUTER_APP_NAME,
+        values={"connection-sharing": "true"},
+    )
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, MYSQL_ROUTER_APP_NAME),
+        timeout=10 * MINUTE_SECS,
+    )
+
+    attempts = 10
+    conn_ids = fetch_connection_ids(juju, attempts)
+    assert len(conn_ids) == 1
+
+
+def fetch_connection_ids(juju: Juju, num_connections: int) -> set:
+    """Fetches the connection ids."""
+    router_leader = get_app_leader(juju, MYSQL_ROUTER_APP_NAME)
+    server_leader = get_app_leader(juju, MYSQL_SERVER_APP_NAME)
+    server_creds = get_mysql_server_credentials(juju, server_leader, "charmed-operator")
+
+    connections = []
+    connection_ids = []
+
+    # The total sleep seconds across all iterations
+    # must be lower than MySQL Router `idle_timeout`.
+    # Otherwise, the connections will not be reused.
+    for i in range(num_connections):
+        connection = mysql.connector.connect(
+            user=server_creds["username"],
+            password=server_creds["password"],
+            host=get_unit_address(juju, MYSQL_ROUTER_APP_NAME, router_leader),
+            port=6446,
+        )
+
+        cursor = connection.cursor()
+        cursor.execute("SELECT CONNECTION_ID();")
+
+        connection_id = cursor.fetchone()[0]
+        connection.commit()
+        cursor.close()
+
+        connections.append(connection)
+        connection_ids.append(connection_id)
+
+        # This sleep time needs to be higher than the value of the
+        # MySQL Router `connection_sharing_delay` (defaults to `1`).
+        # Otherwise, the connections will not be reused
+        time.sleep(2)
+
+    for connection in connections:
+        connection.close()
+
+    return set(connection_ids)

--- a/kubernetes/tests/spread/integration/test_conn_sharing.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_conn_sharing.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_conn_sharing.py
+environment:
+  TEST_MODULE: test_conn_sharing.py
+execute: |
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/machines/config.yaml
+++ b/machines/config.yaml
@@ -2,6 +2,23 @@
 # See LICENSE file for licensing details.
 
 options:
+  connection-sharing:
+    description: |
+      Enable MySQL Router connection pooling and sharing.
+
+      When enabled, MySQL Router pools server connections and shares them between
+      client connections. This reduces the number of connections to the MySQL server
+      and frees resources bound to idle connections.
+
+      Note: Connection sharing has some limitations - certain SQL features like
+      GET DIAGNOSTICS, LAST_INSERT_ID(), SQL_CALC_FOUND_ROWS, GET_LOCK(), user
+      variables, temporary tables, and prepared statements may not work as expected
+      or will prevent connection pooling until the connection is reset.
+
+      See https://dev.mysql.com/doc/mysql-router/8.0/en/mysql-router-general-features-connection-sharing.html
+    type: boolean
+    default: false
+
   vip:
     description: |
       Virtual IP to use to front mysql router units. Used only in case of external node connection.

--- a/machines/config.yaml
+++ b/machines/config.yaml
@@ -15,7 +15,7 @@ options:
       variables, temporary tables, and prepared statements may not work as expected
       or will prevent connection pooling until the connection is reset.
 
-      See https://dev.mysql.com/doc/mysql-router/8.0/en/mysql-router-general-features-connection-sharing.html
+      See https://dev.mysql.com/doc/mysql-router/8.4/en/mysql-router-general-features-connection-sharing.html
     type: boolean
     default: false
 

--- a/machines/tests/integration/integration/test_conn_sharing.py
+++ b/machines/tests/integration/integration/test_conn_sharing.py
@@ -1,0 +1,140 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+import time
+
+import jubilant
+import mysql.connector
+from jubilant import Juju
+
+from ..helpers_new import (
+    MINUTE_SECS,
+    get_app_leader,
+    get_mysql_server_credentials,
+    get_unit_address,
+    wait_for_apps_status,
+)
+
+MYSQL_ROUTER_APP_NAME = "mysql-router"
+MYSQL_SERVER_APP_NAME = "mysql"
+MYSQL_TEST_APP_NAME = "mysql-test-app"
+
+
+def test_deploy_and_relate(juju: Juju, charm: str, ubuntu_base: str) -> None:
+    """Test the database relation."""
+    logging.info("Deploying all the applications")
+    juju.deploy(
+        charm=MYSQL_SERVER_APP_NAME,
+        app=MYSQL_SERVER_APP_NAME,
+        base=ubuntu_base,
+        channel="8.4/edge",
+        config={"profile": "testing"},
+        # MySQL Router 8.4 requires cluster quorum for R/W traffic,
+        # because of the unreachable_quorum_allowed_traffic config option
+        # (only observable upon process restart)
+        num_units=3,
+    )
+    juju.deploy(
+        charm=charm,
+        app=MYSQL_ROUTER_APP_NAME,
+        base=ubuntu_base,
+        num_units=1,
+    )
+    juju.deploy(
+        charm=MYSQL_TEST_APP_NAME,
+        app=MYSQL_TEST_APP_NAME,
+        base=ubuntu_base,
+        channel="latest/edge",
+        num_units=1,
+    )
+
+    logging.info("Relating the applications")
+    juju.integrate(
+        f"{MYSQL_SERVER_APP_NAME}:database",
+        f"{MYSQL_ROUTER_APP_NAME}:backend-database",
+    )
+    juju.integrate(
+        f"{MYSQL_TEST_APP_NAME}:database",
+        f"{MYSQL_ROUTER_APP_NAME}:database",
+    )
+
+    logging.info("Wait for applications to become active")
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active),
+        timeout=20 * MINUTE_SECS,
+        delay=5.0,
+    )
+
+
+def test_connection_sharing_disabled(juju: Juju) -> None:
+    """Test connection sharing disabled mode."""
+    juju.config(
+        app=MYSQL_ROUTER_APP_NAME,
+        values={"connection-sharing": "false"},
+    )
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, MYSQL_ROUTER_APP_NAME),
+        timeout=10 * MINUTE_SECS,
+    )
+
+    attempts = 10
+    conn_ids = fetch_connection_ids(juju, attempts)
+    assert len(conn_ids) == attempts
+
+
+def test_connection_sharing_enabled(juju: Juju) -> None:
+    """Test connection sharing enabled mode."""
+    juju.config(
+        app=MYSQL_ROUTER_APP_NAME,
+        values={"connection-sharing": "true"},
+    )
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, MYSQL_ROUTER_APP_NAME),
+        timeout=10 * MINUTE_SECS,
+    )
+
+    attempts = 10
+    conn_ids = fetch_connection_ids(juju, attempts)
+    assert len(conn_ids) == 1
+
+
+def fetch_connection_ids(juju: Juju, num_connections: int) -> set:
+    """Fetches the connection ids."""
+    router_leader = get_app_leader(juju, MYSQL_ROUTER_APP_NAME)
+    server_leader = get_app_leader(juju, MYSQL_SERVER_APP_NAME)
+    server_creds = get_mysql_server_credentials(juju, server_leader, "charmed-operator")
+
+    connections = []
+    connection_ids = []
+
+    # The total sleep seconds across all iterations
+    # must be lower than MySQL Router `idle_timeout`.
+    # Otherwise, the connections will not be reused.
+    for i in range(num_connections):
+        connection = mysql.connector.connect(
+            user=server_creds["username"],
+            password=server_creds["password"],
+            host=get_unit_address(juju, MYSQL_ROUTER_APP_NAME, router_leader),
+            port=6446,
+        )
+
+        cursor = connection.cursor()
+        cursor.execute("SELECT CONNECTION_ID();")
+
+        connection_id = cursor.fetchone()[0]
+        connection.commit()
+        cursor.close()
+
+        connections.append(connection)
+        connection_ids.append(connection_id)
+
+        # This sleep time needs to be higher than the value of the
+        # MySQL Router `connection_sharing_delay` (defaults to `1`).
+        # Otherwise, the connections will not be reused
+        time.sleep(2)
+
+    for connection in connections:
+        connection.close()
+
+    return set(connection_ids)

--- a/machines/tests/spread/integration/test_conn_sharing.py/task.yaml
+++ b/machines/tests/spread/integration/test_conn_sharing.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_conn_sharing.py
+environment:
+  TEST_MODULE: test_conn_sharing.py
+execute: |
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results


### PR DESCRIPTION
This PR exposes a `connection-sharing` config option to enable/disable MySQL Router 8.4+ connection-sharing [feature](https://dev.mysql.com/doc/mysql-router/8.4/en/mysql-router-general-features-connection-sharing.html). The proposed config options have been available since version 8.0.32, but the feature **does not** work in 8.0 versions.

### Decisions:

- Set [idle-timeout](https://dev.mysql.com/doc/mysql-router/8.4/en/mysql-router-conf-options.html#option_mysqlrouter_idle_timeout_connection-pool) to `60` seconds. Recommended value by Miguel Araujo (Oracle).
- Set [max-idle-server-connections](https://dev.mysql.com/doc/mysql-router/8.4/en/mysql-router-conf-options.html#option_mysqlrouter_max_idle_server_connections_connection-pool) to `1000`. Arbitrary high enough value proposed by Paulo Machado (MySQL).

### Additional changes

I needed to harmonize the `execute_queries_in_unit` test helper between K8s and VM, so that it is able to receive both a host and a port value, needed when directing the connections through MySQL Router.