### PR TITLE
[MISC] 8.4 - Cleanup Juju missing symbolic link

### DIFF
--- a/machines/src/snap.py
+++ b/machines/src/snap.py
@@ -252,15 +252,6 @@ class Snap(common.container.Container):
             _raise_if_snap_installed_not_by_this_charm(unit=unit, model_uuid=model_uuid)
             return
 
-        # Create /sbin symlinks for fuse mount helpers, missing on
-        # resolute where /sbin and /usr/sbin are not merged,
-        # causing snapd's syscheck to fail.
-        for helper in ["mount.fuse", "mount.fuse3"]:
-            src = pathlib.Path(f"/usr/sbin/{helper}")
-            dst = pathlib.Path(f"/sbin/{helper}")
-            if src.exists() and not dst.exists():
-                dst.symlink_to(src)
-
         # Install snap
         logger.info(f"Installing snap revision {repr(snap_revision)}")
         unit.status = ops.MaintenanceStatus("Installing snap")


### PR DESCRIPTION
This PR cleans up the work-around for the Juju missing symbolic link between `/sbin` and `/usr/sbin`, now that the path for the remove-services script has been fixed (see [issue](https://github.com/juju/juju/issues/22713)).

---

Blocked until Juju `3.6.26` is released.