### PR TITLE
[DPE-10198] 8.0 - Fix connectivity-change check

### DIFF
--- a/common/common/workload.py
+++ b/common/common/workload.py
@@ -377,6 +377,29 @@ class RunningWorkload(Workload):
         )
         logger.debug("Enabled MySQL Router exporter service")
 
+    def _router_running_correctly(self, event) -> bool:
+        """Determine whether the router is running correctly for the current connectivity mode."""
+        charm_port_exposed = self._charm.is_externally_accessible(event=event)
+        socket_file_exists = self._container.path("/run/mysqlrouter/mysql.sock").exists()
+
+        # - Kubernetes (charm_port_exposed=None):
+        #   There is no socket/TCP distinction at the charm level, so the service enabled state is used.
+        #
+        # - Machines TCP mode (charm_port_exposed=True):
+        #   MySQL Router never creates socket files in this mode, so socket file existence
+        #   cannot be used as a proxy. Instead, "service enabled AND no stale socket file" is used.
+        #   Without the stale-socket-file check, a switch from socket→TCP would not trigger a re-bootstrap.
+        #
+        # - Machines socket mode (charm_port_exposed=False):
+        #   The socket file at /run/mysqlrouter/mysql.sock is created by MySQL Router on startup and
+        #   removed on clean shutdown, making it reliable proxy for "router is running in socket mode".
+        if charm_port_exposed is None:
+            return self._container.mysql_router_service_enabled
+        elif charm_port_exposed:
+            return self._container.mysql_router_service_enabled and not socket_file_exists
+        else:
+            return socket_file_exists
+
     def reconcile(
         self,
         *,
@@ -394,11 +417,6 @@ class RunningWorkload(Workload):
                 "`key`, `certificate`, and `certificate_authority` arguments required when tls=True"
             )
 
-        # If the host or port changes, MySQL Router will receive a topology change notification.
-        # Therefore, if the host or port changes, we do not need to restart MySQL Router.
-        is_charm_exposed = self._charm.is_externally_accessible(event=event)
-        socket_file_exists = self._container.path("/run/mysqlrouter/mysql.sock").exists()
-
         # If the router is not in the cluster set, disable to restart it
         # This can happen when the server is scaled to zero and back
         try:
@@ -411,8 +429,12 @@ class RunningWorkload(Workload):
                 "Disabling router"
             )
 
+        # If the router is NOT running correctly, _disable_router() is called to wipe the data
+        # and config directories before the subsequent _enable_router() re-bootstraps.
+        # This is essential: a failed bootstrap may write partial keyring data that causes
+        # the next bootstrap attempt to fail with "Error: Keyring decryption failed".
         if any((
-            is_charm_exposed == socket_file_exists,
+            self._router_running_correctly(event) is False,
             self._router_id not in cluster_set_routers,
         )):
             self._disable_router()

--- a/machines/tests/integration/helpers_new.py
+++ b/machines/tests/integration/helpers_new.py
@@ -118,13 +118,11 @@ def get_unit_address(juju: Juju, app_name: str, unit_name: str) -> str:
     raise Exception("No application unit found")
 
 
-def get_unit_certificate_issuer(juju: Juju, unit_name: str, address=None, socket=None) -> str:
+def get_unit_certificate_issuer(juju: Juju, unit_name: str, host: str, port: int) -> str:
     """Get the TLS certificate issuer string."""
-    connect_args = f"-connect {address}" if address else f"-unix {socket}"
-
     output = juju.ssh(
         command=(
-            f"openssl s_client -showcerts -starttls mysql {connect_args} < /dev/null "
+            f"openssl s_client -showcerts -starttls mysql -connect {host}:{port} < /dev/null "
             f"| openssl x509 -text "
             f"| grep Issuer"
         ),

--- a/machines/tests/integration/integration/test_data_integrator.py
+++ b/machines/tests/integration/integration/test_data_integrator.py
@@ -117,24 +117,23 @@ def test_data_integrator_connectivity_with_tls(juju: Juju, charm: str, ubuntu_ba
         action="get-credentials",
     )
 
-    mysql_user = data_integrator_creds.results["mysql"]["username"]
-    mysql_pass = data_integrator_creds.results["mysql"]["password"]
-    mysql_host = data_integrator_creds.results["mysql"]["endpoints"].split(",")[0].split(":")[0]
-    mysql_port = data_integrator_creds.results["mysql"]["endpoints"].split(",")[0].split(":")[1]
+    router_user = data_integrator_creds.results["mysql"]["username"]
+    router_pass = data_integrator_creds.results["mysql"]["password"]
+    router_host = data_integrator_creds.results["mysql"]["endpoints"].split(",")[0].split(":")[0]
+    router_port = data_integrator_creds.results["mysql"]["endpoints"].split(",")[0].split(":")[1]
 
     logging.info("Ensuring no data exists in the test database")
     tables = execute_queries_against_unit(
-        username=mysql_user,
-        password=mysql_pass,
-        host=mysql_host,
-        port=mysql_port,
+        username=router_user,
+        password=router_pass,
+        host=router_host,
+        port=router_port,
         queries=[f"SHOW TABLES IN {TEST_DATABASE_NAME};"],
     )
     assert len(tables) == 0
 
-    router_address = f"{mysql_host}:{mysql_port}"
     router_leader = get_app_leader(juju, MYSQL_ROUTER_APP_NAME)
-    router_issuer = get_unit_certificate_issuer(juju, router_leader, address=router_address)
+    router_issuer = get_unit_certificate_issuer(juju, router_leader, router_host, router_port)
     assert "CN = MySQL_Router_Auto_Generated_CA_Certificate" in router_issuer
 
     logging.info("Relating TLS application")
@@ -150,14 +149,14 @@ def test_data_integrator_connectivity_with_tls(juju: Juju, charm: str, ubuntu_ba
     ):
         with attempt:
             assert "CN = Test CA" in (
-                get_unit_certificate_issuer(juju, router_leader, address=router_address)
+                get_unit_certificate_issuer(juju, router_leader, router_host, router_port)
             )
 
     execute_queries_against_unit(
-        username=mysql_user,
-        password=mysql_pass,
-        host=mysql_host,
-        port=mysql_port,
+        username=router_user,
+        password=router_pass,
+        host=router_host,
+        port=router_port,
         queries=[
             f"CREATE TABLE {TEST_DATABASE_NAME}.{TEST_TABLE_NAME} (id int, primary key(id));",
             f"INSERT INTO {TEST_DATABASE_NAME}.{TEST_TABLE_NAME} VALUES (1), (2);",
@@ -166,10 +165,10 @@ def test_data_integrator_connectivity_with_tls(juju: Juju, charm: str, ubuntu_ba
     )
 
     data = execute_queries_against_unit(
-        username=mysql_user,
-        password=mysql_pass,
-        host=mysql_host,
-        port=mysql_port,
+        username=router_user,
+        password=router_pass,
+        host=router_host,
+        port=router_port,
         queries=[f"SELECT * FROM {TEST_DATABASE_NAME}.{TEST_TABLE_NAME};"],
     )
     assert data == [1, 2]
@@ -187,14 +186,14 @@ def test_data_integrator_connectivity_with_tls(juju: Juju, charm: str, ubuntu_ba
     ):
         with attempt:
             assert "CN = MySQL_Router_Auto_Generated_CA_Certificate" in (
-                get_unit_certificate_issuer(juju, router_leader, address=router_address)
+                get_unit_certificate_issuer(juju, router_leader, router_host, router_port)
             )
 
     data = execute_queries_against_unit(
-        username=mysql_user,
-        password=mysql_pass,
-        host=mysql_host,
-        port=mysql_port,
+        username=router_user,
+        password=router_pass,
+        host=router_host,
+        port=router_port,
         queries=[f"SELECT * FROM {TEST_DATABASE_NAME}.{TEST_TABLE_NAME};"],
     )
     assert data == [1, 2]

--- a/machines/tests/integration/integration/test_exporter_with_tls.py
+++ b/machines/tests/integration/integration/test_exporter_with_tls.py
@@ -13,6 +13,7 @@ from ..helpers_new import (
     MINUTE_SECS,
     check_router_metrics_endpoint,
     get_app_leader,
+    get_unit_address,
     get_unit_certificate_issuer,
     wait_for_apps_status,
 )
@@ -21,8 +22,6 @@ GRAFANA_AGENT_APP_NAME = "grafana-agent"
 MYSQL_ROUTER_APP_NAME = "mysql-router"
 MYSQL_SERVER_APP_NAME = "mysql"
 MYSQL_TEST_APP_NAME = "mysql-test-app"
-
-MYSQL_ROUTER_SOCKET = "/var/snap/charmed-mysql/common/run/mysqlrouter/mysql.sock"
 
 if juju_.is_3_or_higher:
     TLS_APP_NAME = "self-signed-certificates"
@@ -95,7 +94,8 @@ def test_exporter_endpoint(juju: Juju, charm: str, ubuntu_base: str) -> None:
     )
 
     router_leader = get_app_leader(juju, MYSQL_ROUTER_APP_NAME)
-    router_issuer = get_unit_certificate_issuer(juju, router_leader, socket=MYSQL_ROUTER_SOCKET)
+    router_address = get_unit_address(juju, MYSQL_ROUTER_APP_NAME, router_leader)
+    router_issuer = get_unit_certificate_issuer(juju, router_leader, router_address, 6446)
     assert "CN = MySQL_Router_Auto_Generated_CA_Certificate" in router_issuer
 
     logging.info("Deploying TLS application")
@@ -149,7 +149,7 @@ def test_exporter_endpoint(juju: Juju, charm: str, ubuntu_base: str) -> None:
     ):
         with attempt:
             assert "CN = Test CA" in (
-                get_unit_certificate_issuer(juju, router_leader, socket=MYSQL_ROUTER_SOCKET)
+                get_unit_certificate_issuer(juju, router_leader, router_address, 6446)
             )
 
     logging.info("Unrelating TLS application")
@@ -165,5 +165,5 @@ def test_exporter_endpoint(juju: Juju, charm: str, ubuntu_base: str) -> None:
     ):
         with attempt:
             assert "CN = MySQL_Router_Auto_Generated_CA_Certificate" in (
-                get_unit_certificate_issuer(juju, router_leader, socket=MYSQL_ROUTER_SOCKET)
+                get_unit_certificate_issuer(juju, router_leader, router_address, 6446)
             )

--- a/machines/tests/integration/integration/test_hacluster.py
+++ b/machines/tests/integration/integration/test_hacluster.py
@@ -91,16 +91,16 @@ def test_external_connectivity_with_ha_cluster(juju: Juju, charm: str, ubuntu_ba
     data_integrator_leader = get_app_leader(juju, DATA_INTEGRATOR_APP_NAME)
     data_integrator_creds = juju.run(unit=data_integrator_leader, action="get-credentials")
 
-    mysql_user = data_integrator_creds.results["mysql"]["username"]
-    mysql_pass = data_integrator_creds.results["mysql"]["password"]
-    mysql_host = data_integrator_creds.results["mysql"]["endpoints"].split(",")[0].split(":")[0]
-    mysql_port = data_integrator_creds.results["mysql"]["endpoints"].split(",")[0].split(":")[1]
+    router_user = data_integrator_creds.results["mysql"]["username"]
+    router_pass = data_integrator_creds.results["mysql"]["password"]
+    router_host = data_integrator_creds.results["mysql"]["endpoints"].split(",")[0].split(":")[0]
+    router_port = data_integrator_creds.results["mysql"]["endpoints"].split(",")[0].split(":")[1]
 
     databases = execute_queries_against_unit(
-        username=mysql_user,
-        password=mysql_pass,
-        host=mysql_host,
-        port=mysql_port,
+        username=router_user,
+        password=router_pass,
+        host=router_host,
+        port=router_port,
         queries=["SHOW DATABASES;"],
     )
 
@@ -108,7 +108,7 @@ def test_external_connectivity_with_ha_cluster(juju: Juju, charm: str, ubuntu_ba
     assert TEST_DATABASE_NAME in databases
 
     logging.info("Ensure provided host in a data-integrator IP")
-    assert mysql_host in [
+    assert router_host in [
         get_unit_machine_address(juju, DATA_INTEGRATOR_APP_NAME, unit)
         for unit in get_app_units(juju, DATA_INTEGRATOR_APP_NAME)
     ]
@@ -133,7 +133,7 @@ def test_external_connectivity_with_ha_cluster(juju: Juju, charm: str, ubuntu_ba
     )
 
     global MYSQL_ROUTER_VIP
-    MYSQL_ROUTER_VIP = generate_next_available_ip(juju, mysql_host, [])
+    MYSQL_ROUTER_VIP = generate_next_available_ip(juju, router_host, [])
 
     logging.info("Configuring MySQL Router VIP")
     juju.config(
@@ -149,7 +149,7 @@ def test_external_connectivity_with_ha_cluster(juju: Juju, charm: str, ubuntu_ba
     logging.info("Ensuring MySQL Server is accessible via VIP")
     check_server_accessible_virtual_ip(juju, MYSQL_ROUTER_VIP)
 
-    MYSQL_ROUTER_VIP = generate_next_available_ip(juju, mysql_host, [MYSQL_ROUTER_VIP])
+    MYSQL_ROUTER_VIP = generate_next_available_ip(juju, router_host, [MYSQL_ROUTER_VIP])
 
     logging.info("Configuring MySQL Router VIP")
     juju.config(
@@ -209,10 +209,11 @@ def test_router_certificates(juju: Juju) -> None:
         action="get-credentials",
     )
 
-    mysql_addr = data_integrator_creds.results["mysql"]["endpoints"].split(",")[0]
+    router_host = data_integrator_creds.results["mysql"]["endpoints"].split(",")[0].split(":")[0]
+    router_port = data_integrator_creds.results["mysql"]["endpoints"].split(",")[0].split(":")[1]
 
     router_leader = get_app_leader(juju, MYSQL_ROUTER_APP_NAME)
-    router_issuer = get_unit_certificate_issuer(juju, router_leader, address=mysql_addr)
+    router_issuer = get_unit_certificate_issuer(juju, router_leader, router_host, router_port)
     assert "CN = MySQL_Router_Auto_Generated_CA_Certificate" in router_issuer
 
     logging.info("Deploying TLS")
@@ -250,7 +251,7 @@ def test_router_certificates(juju: Juju) -> None:
     ):
         with attempt:
             assert "CN = Test CA" in (
-                get_unit_certificate_issuer(juju, router_leader, address=mysql_addr)
+                get_unit_certificate_issuer(juju, router_leader, router_host, router_port)
             )
 
     logging.info("Unrelating TLS application")
@@ -266,7 +267,7 @@ def test_router_certificates(juju: Juju) -> None:
     ):
         with attempt:
             assert "CN = MySQL_Router_Auto_Generated_CA_Certificate" in (
-                get_unit_certificate_issuer(juju, router_leader, address=mysql_addr)
+                get_unit_certificate_issuer(juju, router_leader, router_host, router_port)
             )
 
     logging.info("Ensuring MySQL Server is accessible via VIP")

--- a/machines/tests/integration/integration/test_tls.py
+++ b/machines/tests/integration/integration/test_tls.py
@@ -11,6 +11,7 @@ from .. import architecture, juju_
 from ..helpers_new import (
     MINUTE_SECS,
     get_app_leader,
+    get_unit_address,
     get_unit_certificate_issuer,
     wait_for_apps_status,
 )
@@ -18,8 +19,6 @@ from ..helpers_new import (
 MYSQL_ROUTER_APP_NAME = "mysql-router"
 MYSQL_SERVER_APP_NAME = "mysql"
 MYSQL_TEST_APP_NAME = "mysql-test-app"
-
-MYSQL_ROUTER_SOCKET = "/var/snap/charmed-mysql/common/run/mysqlrouter/mysql.sock"
 
 if juju_.is_3_or_higher:
     TLS_APP_NAME = "self-signed-certificates"
@@ -87,6 +86,7 @@ def test_deploy_and_relate(juju: Juju, charm: str, ubuntu_base: str) -> None:
 def test_connected_encryption(juju: Juju) -> None:
     """Test encryption when backend database is using TLS."""
     router_leader = get_app_leader(juju, MYSQL_ROUTER_APP_NAME)
+    router_address = get_unit_address(juju, MYSQL_ROUTER_APP_NAME, router_leader)
 
     for attempt in Retrying(
         stop=stop_after_delay(5 * MINUTE_SECS),
@@ -95,7 +95,7 @@ def test_connected_encryption(juju: Juju) -> None:
     ):
         with attempt:
             assert "CN = MySQL_Router_Auto_Generated_CA_Certificate" in (
-                get_unit_certificate_issuer(juju, router_leader, socket=MYSQL_ROUTER_SOCKET)
+                get_unit_certificate_issuer(juju, router_leader, router_address, 6446)
             )
 
     logging.info("Relating TLS application")
@@ -111,7 +111,7 @@ def test_connected_encryption(juju: Juju) -> None:
     ):
         with attempt:
             assert "CN = Test CA" in (
-                get_unit_certificate_issuer(juju, router_leader, socket=MYSQL_ROUTER_SOCKET)
+                get_unit_certificate_issuer(juju, router_leader, router_address, 6446)
             )
 
     logging.info("Unrelating TLS application")
@@ -127,5 +127,5 @@ def test_connected_encryption(juju: Juju) -> None:
     ):
         with attempt:
             assert "CN = MySQL_Router_Auto_Generated_CA_Certificate" in (
-                get_unit_certificate_issuer(juju, router_leader, socket=MYSQL_ROUTER_SOCKET)
+                get_unit_certificate_issuer(juju, router_leader, router_address, 6446)
             )


### PR DESCRIPTION
This PR fixes a bug where, when an application passes the `external_node_connectivity` flag to the DP relation data, MySQL Router is unable to detect that it should restart itself after going through a Juju refresh. The existing condition is not complex enough to capture all the possible cases where we wanted to do a restart.

### Additional changes
We also needed to harmonize K8s and VM `get_unit_certificate_issuer` test helpers, now that MySQL Test app asks for the MySQL Router to be externally connectable (no socket available).
