### PR TITLE
[MISC] 8.4 - Enable data-integrator tests

### DIFF
--- a/kubernetes/tests/integration/integration/test_expose_external.py
+++ b/kubernetes/tests/integration/integration/test_expose_external.py
@@ -53,8 +53,8 @@ def test_expose_external(juju: Juju, charm: str) -> None:
     juju.deploy(
         charm=DATA_INTEGRATOR_APP_NAME,
         app=DATA_INTEGRATOR_APP_NAME,
-        base="ubuntu@24.04",
-        channel="latest/stable",
+        base="ubuntu@26.04",
+        channel="latest/edge",
         config={"database-name": TEST_DATABASE_NAME},
         num_units=1,
     )

--- a/machines/tests/integration/integration/test_data_integrator.py
+++ b/machines/tests/integration/integration/test_data_integrator.py
@@ -46,7 +46,7 @@ def test_data_integrator_connectivity(juju: Juju, charm: str, ubuntu_base: str) 
         charm=DATA_INTEGRATOR_APP_NAME,
         app=DATA_INTEGRATOR_APP_NAME,
         base=ubuntu_base,
-        channel="latest/stable",
+        channel="latest/edge",
         config={"database-name": TEST_DATABASE_NAME},
         num_units=1,
     )

--- a/machines/tests/integration/integration/test_hacluster.py
+++ b/machines/tests/integration/integration/test_hacluster.py
@@ -51,7 +51,7 @@ def test_external_connectivity_with_ha_cluster(juju: Juju, charm: str, ubuntu_ba
         charm=DATA_INTEGRATOR_APP_NAME,
         app=DATA_INTEGRATOR_APP_NAME,
         base=ubuntu_base,
-        channel="latest/stable",
+        channel="latest/edge",
         config={"database-name": TEST_DATABASE_NAME},
         num_units=4,
     )

--- a/machines/tests/spread/integration/test_data_integrator.py/task.yaml
+++ b/machines/tests/spread/integration/test_data_integrator.py/task.yaml
@@ -2,8 +2,6 @@ summary: test_data_integrator.py
 environment:
   TEST_MODULE: test_data_integrator.py
 execute: |
-  # TODO: Uncomment when data-integrator gets built for Ubuntu 26.04
-  # tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
-  exit 0
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_hacluster.py/task.yaml
+++ b/machines/tests/spread/integration/test_hacluster.py/task.yaml
@@ -2,7 +2,7 @@ summary: test_hacluster.py
 environment:
   TEST_MODULE: test_hacluster.py
 execute: |
-  # TODO: Uncomment when data-integrator gets built for Ubuntu 26.04
+  # TODO: Uncomment when HA-Cluster gets built for Ubuntu 26.04
   # tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
   exit 0
 artifacts:


### PR DESCRIPTION
This PR enables the data-integrator tests after it has been built + released for the Ubuntu 26.04 base.