### PR TITLE
[DPE-10897] Fix and re-enable upgrade test on machines

### DIFF
--- a/common/common/workload.py
+++ b/common/common/workload.py
@@ -433,7 +433,7 @@ class RunningWorkload(Workload):
                 return False
             try:
                 self._charm.wait_until_mysql_router_ready(event=event)
-            except AssertionError:
+            except server_exceptions.Error:
                 return False
             return True
         else:

--- a/common/common/workload.py
+++ b/common/common/workload.py
@@ -427,7 +427,13 @@ class RunningWorkload(Workload):
         if charm_port_exposed is None:
             return self._container.mysql_router_service_enabled
         elif charm_port_exposed:
-            return self._container.mysql_router_service_enabled and not socket_file_exists
+            # After a snap refresh the service may be "enabled"
+            # without actually binding to the port
+            if not self._container.mysql_router_service_enabled or socket_file_exists:
+                return False
+            with socket.socket() as s:
+                s.settimeout(1)
+                return s.connect_ex(("localhost", self._charm._READ_WRITE_PORT)) == 0
         else:
             return socket_file_exists
 

--- a/common/common/workload.py
+++ b/common/common/workload.py
@@ -431,9 +431,11 @@ class RunningWorkload(Workload):
             # without actually binding to the port
             if not self._container.mysql_router_service_enabled or socket_file_exists:
                 return False
-            with socket.socket() as s:
-                s.settimeout(1)
-                return s.connect_ex(("localhost", self._charm._READ_WRITE_PORT)) == 0
+            try:
+                self._charm.wait_until_mysql_router_ready(event=event)
+            except AssertionError:
+                return False
+            return True
         else:
             return socket_file_exists
 

--- a/kubernetes/tests/integration/integration/test_upgrade.py
+++ b/kubernetes/tests/integration/integration/test_upgrade.py
@@ -78,7 +78,7 @@ def test_deploy_edge(juju: Juju) -> None:
     )
 
 
-def test_upgrade_from_edge(juju: Juju, charm: str) -> None:
+def test_upgrade_from_edge(juju: Juju, charm: str, continuous_writes) -> None:
     """Upgrade mysqlrouter while ensuring continuous writes incrementing."""
     logging.info("Ensure continuous writes are incrementing")
     check_server_writes_increment(juju, MYSQL_SERVER_APP_NAME)

--- a/machines/src/charm.py
+++ b/machines/src/charm.py
@@ -24,6 +24,7 @@ import common.relations.cos
 import common.relations.database_provides
 import common.relations.database_requires
 import common.relations.tls
+import common.server_exceptions
 import common.workload
 import ops.log
 import tenacity
@@ -230,8 +231,10 @@ class MachineSubordinateRouterCharm(common.abstract_charm.MySQLRouterCharm):
                             with socket.socket(socket.AF_UNIX) as s:
                                 assert s.connect_ex(str(self._container.path(socket_file))) == 0
         except AssertionError:
-            logger.exception("Unable to connect to MySQL Router")
-            raise
+            logger.warning("Unable to connect to MySQL Router")
+            raise common.server_exceptions.Error(
+                ops.WaitingStatus("MySQL Router not ready")
+            ) from None
         else:
             logger.debug("MySQL Router is ready")
 

--- a/machines/src/snap.py
+++ b/machines/src/snap.py
@@ -179,7 +179,17 @@ class Snap(common.container.Container):
             if router_is_running:
                 self._snap.restart([self._SERVICE_NAME])
             else:
-                self._snap.start([self._SERVICE_NAME], enable=True)
+                # Retry snap start: after a snap refresh, the mysqlrouter service
+                # can crash repeatedly and hit systemd's StartLimitBurst limit.
+                # Waiting briefly and retrying lets the rate-limit window expire.
+                for attempt in tenacity.Retrying(
+                    stop=tenacity.stop_after_delay(60),
+                    wait=tenacity.wait_fixed(10),
+                    retry=tenacity.retry_if_exception_type(snap_lib.SnapError),
+                    reraise=True,
+                ):
+                    with attempt:
+                        self._snap.start([self._SERVICE_NAME], enable=True)
         else:
             self._snap.stop([self._SERVICE_NAME], disable=True)
 

--- a/machines/tests/integration/integration/test_upgrade.py
+++ b/machines/tests/integration/integration/test_upgrade.py
@@ -4,6 +4,7 @@
 import logging
 import shutil
 import zipfile
+from contextlib import suppress
 from pathlib import Path
 
 import jubilant
@@ -102,26 +103,27 @@ def test_upgrade_from_edge(juju: Juju, charm: str, continuous_writes) -> None:
     # Refresh will be incompatible on PR CI (not edge CI)
     # since unreleased charm versions are always marked as incompatible
     if router_status.current == "blocked" and "incompatible" in router_status.message:
-        logging.info("Application upgrade is blocked due to incompatibility")
-        juju.run(
-            unit=router_app_units[0],
-            action="force-refresh-start",
-            params={"check-compatibility": False},
-            wait=5 * MINUTE_SECS,
+        with suppress(jubilant.TaskError):
+            logging.info("Application upgrade is blocked due to incompatibility")
+            juju.run(
+                unit=router_app_units[0],
+                action="force-refresh-start",
+                params={"check-compatibility": False},
+                wait=5 * MINUTE_SECS,
+            )
+
+        logging.info("Wait for first unit to upgrade")
+        juju.wait(
+            ready=jubilant.all_agents_idle,
+            timeout=5 * MINUTE_SECS,
         )
 
-    logging.info("Wait for first unit to upgrade")
-    juju.wait(
-        ready=jubilant.all_agents_idle,
-        timeout=5 * MINUTE_SECS,
-    )
-
-    logging.info("Resume upgrade")
-    juju.run(
-        unit=router_app_units[1],
-        action="resume-refresh",
-        wait=5 * MINUTE_SECS,
-    )
+        logging.info("Resume upgrade")
+        juju.run(
+            unit=router_app_units[1],
+            action="resume-refresh",
+            wait=5 * MINUTE_SECS,
+        )
 
     logging.info("Wait for upgrade to complete")
     juju.wait(

--- a/machines/tests/integration/integration/test_upgrade.py
+++ b/machines/tests/integration/integration/test_upgrade.py
@@ -4,11 +4,9 @@
 import logging
 import shutil
 import zipfile
-from contextlib import suppress
 from pathlib import Path
 
 import jubilant
-import tenacity
 import tomli
 import tomli_w
 from jubilant import Juju
@@ -104,49 +102,32 @@ def test_upgrade_from_edge(juju: Juju, charm: str, continuous_writes) -> None:
     # Refresh will be incompatible on PR CI (not edge CI)
     # since unreleased charm versions are always marked as incompatible
     if router_status.current == "blocked" and "incompatible" in router_status.message:
-        with suppress(jubilant.TaskError):
-            logging.info("Application upgrade is blocked due to incompatibility")
-            juju.run(
-                unit=router_app_units[0],
-                action="force-refresh-start",
-                params={"check-compatibility": False},
-                wait=5 * MINUTE_SECS,
-            )
-
-        logging.info("Wait for first unit to upgrade")
-        juju.wait(
-            ready=jubilant.all_agents_idle,
-            timeout=5 * MINUTE_SECS,
-        )
-
-        logging.info("Resume upgrade")
+        logging.info("Application upgrade is blocked due to incompatibility")
         juju.run(
-            unit=router_app_units[1],
-            action="resume-refresh",
+            unit=router_app_units[0],
+            action="force-refresh-start",
+            params={"check-compatibility": False},
             wait=5 * MINUTE_SECS,
         )
 
-    # Wait for the upgrade to complete, resolving any units that error
-    # (e.g. the router was not ready within the 30-second timeout after a snap refresh)
-    # Resolving a unit makes Juju re-run the failed hook, which starts a fresh timeout window
-    def _resolve_errored_units(_) -> None:
-        for unit in get_app_units(juju, MYSQL_ROUTER_APP_NAME):
-            unit_status = juju.status().get_units(MYSQL_ROUTER_APP_NAME).get(unit)
-            if unit_status and unit_status.workload_status.current == "error":
-                logging.info(f"Unit {unit} is in error state, resolving and retrying")
-                juju.cli("resolved", unit)
+    logging.info("Wait for first unit to upgrade")
+    juju.wait(
+        ready=jubilant.all_agents_idle,
+        timeout=5 * MINUTE_SECS,
+    )
 
-    for attempt in tenacity.Retrying(
-        stop=tenacity.stop_after_delay(2 * MINUTE_SECS),
-        retry=tenacity.retry_if_exception_type(TimeoutError),
-        after=_resolve_errored_units,
-        reraise=True,
-    ):
-        with attempt:
-            juju.wait(
-                ready=wait_for_apps_status(jubilant.all_active, MYSQL_ROUTER_APP_NAME),
-                timeout=30,
-            )
+    logging.info("Resume upgrade")
+    juju.run(
+        unit=router_app_units[1],
+        action="resume-refresh",
+        wait=5 * MINUTE_SECS,
+    )
+
+    logging.info("Wait for upgrade to complete")
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, MYSQL_ROUTER_APP_NAME),
+        timeout=20 * MINUTE_SECS,
+    )
 
     logging.info("Ensure continuous writes are incrementing")
     check_server_writes_increment(juju, MYSQL_SERVER_APP_NAME)

--- a/machines/tests/integration/integration/test_upgrade.py
+++ b/machines/tests/integration/integration/test_upgrade.py
@@ -8,6 +8,7 @@ from contextlib import suppress
 from pathlib import Path
 
 import jubilant
+import tenacity
 import tomli
 import tomli_w
 from jubilant import Juju
@@ -125,11 +126,27 @@ def test_upgrade_from_edge(juju: Juju, charm: str, continuous_writes) -> None:
             wait=5 * MINUTE_SECS,
         )
 
-    logging.info("Wait for upgrade to complete")
-    juju.wait(
-        ready=wait_for_apps_status(jubilant.all_active, MYSQL_ROUTER_APP_NAME),
-        timeout=20 * MINUTE_SECS,
-    )
+    # Wait for the upgrade to complete, resolving any units that error
+    # (e.g. the router was not ready within the 30-second timeout after a snap refresh)
+    # Resolving a unit makes Juju re-run the failed hook, which starts a fresh timeout window
+    def _resolve_errored_units(_) -> None:
+        for unit in get_app_units(juju, MYSQL_ROUTER_APP_NAME):
+            unit_status = juju.status().get_units(MYSQL_ROUTER_APP_NAME).get(unit)
+            if unit_status and unit_status.workload_status.current == "error":
+                logging.info(f"Unit {unit} is in error state, resolving and retrying")
+                juju.cli("resolved", unit)
+
+    for attempt in tenacity.Retrying(
+        stop=tenacity.stop_after_delay(2 * MINUTE_SECS),
+        retry=tenacity.retry_if_exception_type(TimeoutError),
+        after=_resolve_errored_units,
+        reraise=True,
+    ):
+        with attempt:
+            juju.wait(
+                ready=wait_for_apps_status(jubilant.all_active, MYSQL_ROUTER_APP_NAME),
+                timeout=30,
+            )
 
     logging.info("Ensure continuous writes are incrementing")
     check_server_writes_increment(juju, MYSQL_SERVER_APP_NAME)

--- a/machines/tests/integration/integration/test_upgrade.py
+++ b/machines/tests/integration/integration/test_upgrade.py
@@ -197,9 +197,9 @@ def create_valid_upgrade_charm(charm_file: str | Path) -> None:
             versions = tomli.load(file)
 
     # charm needs to refresh snap to be able to avoid no-op when upgrading.
-    versions["snap"]["revisions"]["x86_64"] = "171"
-    versions["snap"]["revisions"]["aarch64"] = "170"
-    versions["workload"] = "8.4.7"
+    versions["snap"]["revisions"]["x86_64"] = "237"
+    versions["snap"]["revisions"]["aarch64"] = "236"
+    versions["workload"] = "8.4.10"
 
     with zipfile.ZipFile(charm_file, mode="a") as charm_zip:
         charm_zip.writestr("refresh_versions.toml", tomli_w.dumps(versions))

--- a/machines/tests/spread/integration/test_upgrade.py/task.yaml
+++ b/machines/tests/spread/integration/test_upgrade.py/task.yaml
@@ -2,8 +2,6 @@ summary: test_upgrade.py
 environment:
   TEST_MODULE: test_upgrade.py
 execute: |
-  # TODO: Uncomment when the stability is improved (ARM64 variant fails constantly)
-  # tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
-  exit 0
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results


### PR DESCRIPTION
## Problem

The `test_upgrade.py` integration test fails after a charm upgrade because:

1. The mysqlrouter service crashes repeatedly after a snap refresh, hitting systemd's `StartLimitBurst` limit. `snap start` then fails with "Start request repeated too quickly", crashing the charm.
2. `wait_until_mysql_router_ready` raises `AssertionError` after 30 seconds if it can't connect to the router, crashing the charm during a `refresh-v-three` hook. This puts the unit in error state, preventing the router from being restarted.
3. After the crash and hook retry, `reconcile()` sees `mysql_router_service_enabled = True` (snap start succeeded) and skips re-bootstrapping, even though the router process is not actually listening on port 6446. The router stays in a broken state indefinitely.

## Changes

0. Build on top of @sinclert-canonical's #200, and revert #201.

1. **Retry `snap start`** (`machines/src/snap.py`) — wrap `snap start` in `tenacity.Retrying` (60-second timeout, 10-second intervals) to let systemd's rate-limit window expire and retry the start.

2. **Don't crash when the router is not ready** (`machines/src/charm.py`) — instead of raising `AssertionError` from `wait_until_mysql_router_ready` (which puts the unit in error state and stops hooks from firing), raise a `server_exceptions.Error` carrying a `WaitingStatus`. The existing `except server_exceptions.Error` handler in `abstract_charm.reconcile` catches it, sets the unit to `waiting`, and lets `update-status` keep firing. On the next hook, `_router_running_correctly` detects the port is down and re-bootstraps the router. This avoids the need for `juju resolved` — the charm recovers automatically.

3. **Verify router port in `_router_running_correctly`** (`common/common/workload.py`) — for machines TCP mode, check that the router is actually listening by calling `wait_until_mysql_router_ready` (wrapped in try/except `server_exceptions.Error` → return `False`). After a snap refresh, the service may be "enabled" without binding to the port. If the check fails, `reconcile()` will disable and re-enable the router, re-bootstrapping it with a fresh config.