### PR TITLE
[MISC] Fix unit test slowdown from leaking JujuLogHandler instances

### DIFF
--- a/kubernetes/tests/unit/conftest.py
+++ b/kubernetes/tests/unit/conftest.py
@@ -1,8 +1,25 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import logging
+
+import ops.log
 import pytest
 from charms.tempo_coordinator_k8s.v0.charm_tracing import charm_tracing_disabled
+
+
+@pytest.fixture(autouse=True)
+def _clear_juju_log_handlers():
+    """Remove stale JujuLogHandler instances added by scenario/ops on each context.run().
+
+    ops.log.setup_root_logging() unconditionally calls logger.addHandler() on every charm
+    instantiation, but nothing ever removes them. Across thousands of context.run() calls
+    (e.g. the heavily-parametrized scenario tests), handlers accumulate on the root logger,
+    making every log call O(N) and retaining references to dead Context.juju_log lists.
+    """
+    yield
+    root = logging.getLogger()
+    root.handlers[:] = [h for h in root.handlers if not isinstance(h, ops.log.JujuLogHandler)]
 
 
 @pytest.fixture(autouse=True)

--- a/kubernetes/tox.ini
+++ b/kubernetes/tox.ini
@@ -51,8 +51,7 @@ description = Run unit tests
 commands_pre =
     poetry install --only main,charm-libs,unit
 commands =
-    # `--forked` workaround to deal with memory leaks in scenario tests
-    poetry run pytest --forked --numprocesses 120 --cov=src --ignore={[vars]tests_path}/integration/ {posargs}
+    poetry run pytest --numprocesses auto --cov=src --ignore={[vars]tests_path}/integration/ {posargs}
 
 [testenv:integration]
 pass_env =

--- a/machines/tests/unit/conftest.py
+++ b/machines/tests/unit/conftest.py
@@ -1,13 +1,29 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import logging
 import pathlib
 import platform
 
 import ops
+import ops.log
 import pytest
 import tomli
 from charms.tempo_coordinator_k8s.v0.charm_tracing import charm_tracing_disabled
+
+
+@pytest.fixture(autouse=True)
+def _clear_juju_log_handlers():
+    """Remove stale JujuLogHandler instances added by scenario/ops on each context.run().
+
+    ops.log.setup_root_logging() unconditionally calls logger.addHandler() on every charm
+    instantiation, but nothing ever removes them. Across thousands of context.run() calls
+    (e.g. the heavily-parametrized scenario tests), handlers accumulate on the root logger,
+    making every log call O(N) and retaining references to dead Context.juju_log lists.
+    """
+    yield
+    root = logging.getLogger()
+    root.handlers[:] = [h for h in root.handlers if not isinstance(h, ops.log.JujuLogHandler)]
 
 
 @pytest.fixture(autouse=True)

--- a/machines/tox.ini
+++ b/machines/tox.ini
@@ -50,7 +50,7 @@ description = Run unit tests
 commands_pre =
     poetry install --only main,charm-libs,unit
 commands =
-    poetry run pytest --numprocesses 120 --cov=src --ignore={[vars]tests_path}/integration/ {posargs}
+    poetry run pytest --numprocesses auto --cov=src --ignore={[vars]tests_path}/integration/ {posargs}
 
 [testenv:integration]
 description = Run integration tests


### PR DESCRIPTION
## Problem

`ops.log.setup_root_logging()` adds a `JujuLogHandler` to the root logger on every `context.run()` but never removes them. Across the heavily-parametrized scenario tests (~5500 `context.run()` calls in `test_database_relations.py`), handlers accumulate on the root logger, making every log call O(N) and retaining references to dead `Context.juju_log` lists.

This caused unit tests to consume 100% CPU and grow memory until OOM-kill (6+ GB after ~60% of tests). With `--numprocesses 120` the issue was partially masked by sharding across workers.

Notice that CI was not as severely affected, but the slowdown was nonetheless noticeable.

## Solution

Add an autouse fixture in `tests/unit/conftest.py` that strips stale `JujuLogHandler` instances after each test, keeping the handler count bounded.

## Testing

Unit tests now complete in ~2 minutes locally, even without parallelization (previously: hours / OOM-kill).