### PR TITLE
[DPE-10973] 8.4 - Point docs to MySQL 8.4/stable

### DIFF
--- a/kubernetes/docs/how-to/h-deploy-microk8s.md
+++ b/kubernetes/docs/how-to/h-deploy-microk8s.md
@@ -23,8 +23,8 @@ Model           Controller  Cloud/Region        Version  SLA          Timestamp
 wordpress-demo  microk8s    microk8s/localhost  3.6.19   unsupported  14:39:27+02:00
 
 App               Version  Status   Scale  Charm             Channel     Rev  Address         Exposed  Message
-mysql-k8s         8.4.7    active       1  mysql-k8s         8.4/stable   99  10.152.183.189  no       
-mysql-router-k8s  8.4.7    blocked      1  mysql-router-k8s  8.4/stable   69  10.152.183.81   no       Missing relation: database
+mysql-k8s         8.4.10   active       1  mysql-k8s         8.4/stable   99  10.152.183.189  no       
+mysql-router-k8s  8.4.10   blocked      1  mysql-router-k8s  8.4/stable   69  10.152.183.81   no       Missing relation: database
 
 Unit                 Workload  Agent  Address     Ports  Message
 mysql-k8s/0*         active    idle   10.1.12.61         Primary

--- a/kubernetes/docs/how-to/h-enable-monitoring.md
+++ b/kubernetes/docs/how-to/h-enable-monitoring.md
@@ -99,8 +99,8 @@ loki    	active  k8s	   admin/cos.loki
 prometheus  active  k8s	   admin/cos.prometheus
 
 App            	            Version  Status  Scale  Charm           	         Channel 	 Rev  Address     	  Exposed  Message
-mysql-k8s      	             8.4.7   active      1  mysql-k8s      	             8.4/stable  127  10.152.183.105  no
-mysql-router-k8s             8.4.7   active      1  mysql-router-k8s             8.4/edge	 102  10.152.183.92   no
+mysql-k8s      	             8.4.10  active      1  mysql-k8s      	             8.4/stable       10.152.183.105  no
+mysql-router-k8s             8.4.10  active      1  mysql-router-k8s             8.4/stable	      10.152.183.92   no
 mysql-test-app 	             0.0.2   active      1  mysql-test-app 	             stable   	  36  10.152.183.35   no
 opentelemetry-collector-k8s          active      1  opentelemetry-collector-k8s  2/stable     64  10.152.183.141  no
 

--- a/kubernetes/docs/how-to/h-enable-tracing.md
+++ b/kubernetes/docs/how-to/h-enable-tracing.md
@@ -93,8 +93,8 @@ SAAS   Status  Store       URL
 tempo  active  k8s         admin/cos.tempo
 
 App                          Version  Status  Scale  Charm                        Channel        Rev  Address         Exposed  Message
-mysql-k8s                    8.4.7    active      1  mysql-k8s                    8.4/edge       201  10.152.183.58   no
-mysql-router-k8s             8.4.7    active      1  mysql-router-k8s             8.4/edge            10.152.183.50   no
+mysql-k8s                    8.4.10   active      1  mysql-k8s                    8.4/stable          10.152.183.58   no
+mysql-router-k8s             8.4.10   active      1  mysql-router-k8s             8.4/stable          10.152.183.50   no
 mysql-test-app               0.0.2    active      1  mysql-test-app               latest/stable   51  10.152.183.162  no
 opentelemetry-collector-k8s           active      1  opentelemetry-collector-k8s  2/stable       207  10.152.183.164  no
 

--- a/kubernetes/docs/how-to/h-external-access.md
+++ b/kubernetes/docs/how-to/h-external-access.md
@@ -13,8 +13,8 @@ database  uk8s-3-6-1  microk8s/localhost  3.6.19   unsupported  14:39:08Z
 
 App               Version  Status  Scale  Charm             Channel        Rev  Address         Exposed  Message
 data-integrator            active      1  data-integrator   latest/stable   78  10.152.183.44   no       
-mysql-k8s         8.4.7    active      1  mysql-k8s         8.4/edge       210  10.152.183.143  no       
-mysql-router-k8s  8.4.7    active      1  mysql-router-k8s  8.4/edge       531  10.152.183.201  no       
+mysql-k8s         8.4.10   active      1  mysql-k8s         8.4/stable          10.152.183.143  no       
+mysql-router-k8s  8.4.10   active      1  mysql-router-k8s  8.4/stable          10.152.183.201  no       
 
 Unit                 Workload  Agent  Address       Ports  Message
 data-integrator/0*   active    idle   10.1.241.219         
@@ -48,7 +48,7 @@ mysql:
 ok: "True"
 ```
 
-The following shows a mysql client connecting to the the provided endpoints from the data integrator unit (which is deployed in the same K8s namespace, i.e. the same juju model, as MySQL Router K8s):
+The following shows a mysql client connecting to the provided endpoints from the data integrator unit (which is deployed in the same K8s namespace, i.e. the same juju model, as MySQL Router K8s):
 
 ```shell
 $ juju ssh data-integrator/0 bash 

--- a/kubernetes/docs/how-to/h-manage-units.md
+++ b/kubernetes/docs/how-to/h-manage-units.md
@@ -4,12 +4,12 @@
 
 To deploy a single unit of MySQL Router using its default configuration
 ```shell
-juju deploy mysql-router-k8s --channel 8.4 --trust
+juju deploy mysql-router-k8s --channel 8.4/stable --trust
 ```
 
 To deploy MySQL Router in high-availability mode, specify the number of desired units with the `-n` option.
 ```shell
-juju deploy mysql-router-k8s --channel 8.4 --trust -n <number_of_replicas>
+juju deploy mysql-router-k8s --channel 8.4/stable --trust -n <number_of_replicas>
 ```
 
 ## Scaling

--- a/kubernetes/docs/how-to/h-upgrade-minor.md
+++ b/kubernetes/docs/how-to/h-upgrade-minor.md
@@ -95,7 +95,7 @@ After the Router upgrade is completed, upgrade the Server:
 juju refresh mysql-k8s --channel 8.4/edge --trust
 
 # example with specific revision selection
-juju refresh mysql-k8s --revision=89
+juju refresh mysql-k8s --revision=109
 ```
 
 > **:information_source: IMPORTANT:** The Server upgrade will execute only on the highest ordinal unit, for the running example `mysql-k8s/2`, the `juju status` will look like*:
@@ -121,8 +121,8 @@ Model    Controller  Cloud/Region        Version  SLA          Timestamp
 upgrade  microk8s    microk8s/localhost  3.6.19   unsupported  15:56:25+02:00
 
 App               Version  Status   Scale  Charm             Channel   Rev  Address         Exposed  Message
-mysql-k8s         8.4.7    waiting    3/4  mysql-k8s         8.4/edge  109  10.152.183.238  no       installing agent
-mysql-router-k8s  8.4.7    active       4  mysql-router-k8s  8.4/edge   69  10.152.183.184  no       
+mysql-k8s         8.4.8    waiting    3/4  mysql-k8s         8.4/edge  109  10.152.183.238  no       installing agent
+mysql-router-k8s  8.4.8    active       4  mysql-router-k8s  8.4/edge   89  10.152.183.184  no       
 mysql-test-app    0.0.2    active       1  mysql-test-app    stable     26  10.152.183.36   no       
 
 Unit                 Workload     Agent  Address     Ports  Message

--- a/kubernetes/docs/reference/r-testing.md
+++ b/kubernetes/docs/reference/r-testing.md
@@ -18,8 +18,8 @@ There are [a lot of test types](https://en.wikipedia.org/wiki/Software_testing) 
 ```shell
 juju add-model smoke-test
 
-juju deploy mysql-k8s --trust --channel 8.4/edge --config profile=testing
-juju deploy mysql-router-k8s --trust --channel 8.4/edge
+juju deploy mysql-k8s --trust --channel 8.4/stable --config profile=testing
+juju deploy mysql-router-k8s --trust --channel 8.4/stable
 juju relate mysql-k8s mysql-router-k8s
 
 juju scale-application mysql-k8s 3 # (optional)

--- a/kubernetes/docs/tutorial/t-deploy.md
+++ b/kubernetes/docs/tutorial/t-deploy.md
@@ -6,8 +6,8 @@ This is part of the [MySQL Router K8s Tutorial](/t/12176). Please refer to this 
 To deploy Charmed MySQL K8s + MySQL Router K8s, all you need to do is run the following commands:
 
 ```shell
-juju deploy mysql-router-k8s --channel 8.4 --trust
-juju deploy mysql-k8s --channel 8.4 --trust
+juju deploy mysql-router-k8s --channel 8.4/stable --trust
+juju deploy mysql-k8s --channel 8.4/stable --trust
 ```
 Note: `--trust` is required to create some K8s resources.
 
@@ -21,9 +21,9 @@ This command is useful for checking the status of Juju applications and gatherin
 Model     Controller  Cloud/Region        Version  SLA          Timestamp
 tutorial  overlord    microk8s/localhost  3.6.19   unsupported  22:33:45+01:00
 
-App               Version  Status   Scale  Charm             Channel   Rev  Address        Exposed  Message
-mysql-k8s         8.4.7    active       1  mysql-k8s         8.4/edge  109  10.152.183.68  no       
-mysql-router-k8s  8.4.7    blocked      1  mysql-router-k8s  8.4/edge   68  10.152.183.52  no       Missing relation: backend-database
+App               Version  Status   Scale  Charm             Channel     Rev  Address        Exposed  Message
+mysql-k8s         8.4.10   active       1  mysql-k8s         8.4/stable       10.152.183.68  no       
+mysql-router-k8s  8.4.10   blocked      1  mysql-router-k8s  8.4/stable       10.152.183.52  no       Missing relation: backend-database
 
 Unit                 Workload  Agent  Address     Ports  Message
 mysql-k8s/0*         active    idle   10.1.12.36         Primary
@@ -49,10 +49,10 @@ In a couple of seconds, the status will be happy for entire model:
 Model     Controller  Cloud/Region        Version  SLA          Timestamp
 tutorial  overlord    microk8s/localhost  3.6.19   unsupported  22:37:41+01:00
 
-App               Version  Status  Scale  Charm             Channel   Rev  Address         Exposed  Message
-data-integrator            active      1  data-integrator   stable     13  10.152.183.142  no       
-mysql-k8s         8.4.7    active      1  mysql-k8s         8.4/edge  109  10.152.183.68   no       
-mysql-router-k8s  8.4.7    active      1  mysql-router-k8s  8.4/edge   68  10.152.183.52   no       
+App               Version  Status  Scale  Charm             Channel     Rev  Address         Exposed  Message
+data-integrator            active      1  data-integrator   stable       13  10.152.183.142  no       
+mysql-k8s         8.4.10   active      1  mysql-k8s         8.4/stable       10.152.183.68   no       
+mysql-router-k8s  8.4.10   active      1  mysql-router-k8s  8.4/stable       10.152.183.52   no       
 
 Unit                 Workload  Agent  Address     Ports  Message
 data-integrator/0*   active    idle   10.1.12.3          
@@ -79,8 +79,8 @@ mysql:
 The host’s IP address can be found with `juju status` (the application hosting the Router MySQL K8s application):
 ```shell
 ...
-App               Version  Status   Scale  Charm             Channel   Rev  Address         Exposed  Message
-mysql-router-k8s  8.4.7    active       1  mysql-router-k8s  8.4/edge   68  10.152.183.52   no  
+App               Version  Status   Scale  Charm             Channel     Rev  Address         Exposed  Message
+mysql-router-k8s  8.4.10   active       1  mysql-router-k8s  8.4/stable       10.152.183.52   no
 ...
 ```
 
@@ -107,11 +107,11 @@ mysql> show databases;
 You can now interact with MySQL directly using any [MySQL Queries](https://dev.mysql.com/doc/refman/8.4/en/entering-queries.html). For example entering `SELECT VERSION(), CURRENT_DATE;` should output something like:
 ```shell
 mysql> SELECT VERSION(), CURRENT_DATE;
-+------------------------+--------------+
-| VERSION()              | CURRENT_DATE |
-+------------------------+--------------+
-| 8.4.7-0ubuntu0.26.04.1 | 2026-01-22   |
-+------------------------+--------------+
++-------------------------+--------------+
+| VERSION()               | CURRENT_DATE |
++-------------------------+--------------+
+| 8.4.10-0ubuntu0.26.04.1 | 2026-01-22   |
++-------------------------+--------------+
 1 row in set (0.00 sec)
 ```
 

--- a/kubernetes/docs/tutorial/t-enable-tls.md
+++ b/kubernetes/docs/tutorial/t-enable-tls.md
@@ -30,8 +30,8 @@ Model 	  Controller  Cloud/Region    	  Version  SLA          Timestamp
 database  k8s     	  microk8s/localhost  3.6.19   unsupported  12:10:33Z
 
 App                   	Version  Status  Scale  Charm                 	 Channel 	 Rev  Address     	  Exposed  Message
-mysql-k8s             	8.4.7    active  	1  mysql-k8s             	 8.4/stable  127  10.152.183.101  no  	 
-mysql-router-k8s      	8.4.7    active  	1  mysql-router-k8s      	 8.4/edge	 102  10.152.183.92   no  	 
+mysql-k8s             	8.4.10    active  	1  mysql-k8s             	 8.4/stable       10.152.183.101  no  	 
+mysql-router-k8s      	8.4.10    active  	1  mysql-router-k8s      	 8.4/stable	      10.152.183.92   no  	 
 mysql-test-app        	0.0.2    active  	1  mysql-test-app        	 stable   	  36  10.152.183.224  no  	 
 self-signed-certificates         active  	1  self-signed-certificates  stable   	  72  10.152.183.114  no  	 
 

--- a/kubernetes/docs/tutorial/t-manage-units.md
+++ b/kubernetes/docs/tutorial/t-manage-units.md
@@ -17,10 +17,10 @@ You can now watch the scaling process in live using: `juju status --watch 1s`. I
 Model     Controller  Cloud/Region        Version  SLA          Timestamp
 tutorial  overlord    microk8s/localhost  3.6.19   unsupported  22:48:57+01:00
 
-App               Version  Status  Scale  Charm             Channel   Rev  Address         Exposed  Message
-data-integrator            active      1  data-integrator   stable     13  10.152.183.142  no       
-mysql-k8s         8.4.7    active      1  mysql-k8s         8.4/edge  109  10.152.183.68   no       
-mysql-router-k8s  8.4.7    active      3  mysql-router-k8s  8.4/edge   68  10.152.183.52   no       
+App               Version  Status  Scale  Charm             Channel     Rev  Address         Exposed  Message
+data-integrator            active      1  data-integrator   stable       13  10.152.183.142  no       
+mysql-k8s         8.4.10   active      1  mysql-k8s         8.4/stable       10.152.183.68   no       
+mysql-router-k8s  8.4.10   active      3  mysql-router-k8s  8.4/stable       10.152.183.52   no       
 
 Unit                 Workload  Agent  Address     Ports  Message
 data-integrator/0*   active    idle   10.1.12.3          
@@ -34,12 +34,13 @@ The same way you can scale Charmed MySQL:
 ```shell
 juju scale-application mysql-k8s 3
 ```
+
 Make sure all units are active (using `juju status`):
 ```shell
-App               Version  Status  Scale  Charm             Channel   Rev  Address         Exposed  Message
-data-integrator            active      1  data-integrator   stable     13  10.152.183.142  no       
-mysql-k8s         8.4.7    active      3  mysql-k8s         8.4/edge  109  10.152.183.68   no       
-mysql-router-k8s  8.4.7    active      3  mysql-router-k8s  8.4/edge   68  10.152.183.52   no       
+App               Version  Status  Scale  Charm             Channel     Rev  Address         Exposed  Message
+data-integrator            active      1  data-integrator   stable       13  10.152.183.142  no       
+mysql-k8s         8.4.10   active      3  mysql-k8s         8.4/stable       10.152.183.68   no       
+mysql-router-k8s  8.4.10   active      3  mysql-router-k8s  8.4/stable       10.152.183.52   no       
 
 Unit                 Workload  Agent  Address     Ports  Message
 data-integrator/0*   active    idle   10.1.12.3          
@@ -63,10 +64,10 @@ You’ll know that the replica was successfully removed when `juju status --watc
 Model     Controller  Cloud/Region        Version  SLA          Timestamp
 tutorial  overlord    microk8s/localhost  3.6.19   unsupported  22:48:57+01:00
 
-App               Version  Status  Scale  Charm             Channel   Rev  Address         Exposed  Message
-data-integrator            active      1  data-integrator   stable     13  10.152.183.142  no       
-mysql-k8s         8.4.7    active      2  mysql-k8s         8.4/edge  109  10.152.183.68   no       
-mysql-router-k8s  8.4.7    active      2  mysql-router-k8s  8.4/edge   68  10.152.183.52   no       
+App               Version  Status  Scale  Charm             Channel     Rev  Address         Exposed  Message
+data-integrator            active      1  data-integrator   stable       13  10.152.183.142  no       
+mysql-k8s         8.4.10   active      2  mysql-k8s         8.4/stable       10.152.183.68   no       
+mysql-router-k8s  8.4.10   active      2  mysql-router-k8s  8.4/stable       10.152.183.52   no       
 
 Unit                 Workload  Agent  Address     Ports  Message
 data-integrator/0*   active    idle   10.1.12.3          

--- a/kubernetes/terraform/variables.tf
+++ b/kubernetes/terraform/variables.tf
@@ -30,7 +30,7 @@ variable "constraints" {
 variable "channel" {
   description = "Charm channel to deploy from"
   type        = string
-  default     = "8.4/edge"
+  default     = "8.4/stable"
 }
 
 variable "revision" {

--- a/machines/docs/explanation/e-legacy-charm.md
+++ b/machines/docs/explanation/e-legacy-charm.md
@@ -25,7 +25,7 @@ There are [two types of charms](https://juju.is/docs/sdk/charm-taxonomy#heading-
 
 Both legacy and modern charms are [**subordinated**](https://juju.is/docs/sdk/charm-taxonomy#heading--subordinate-charms).
 
-The legacy charm provided SQL endpoints `shared-db` (for the interface `mysql-shared`). The modern charm provides those old endpoint and a new endpoint `database` (for the interface `mysql_client`). Read more details about the available endpoints and interfaces [here](https://charmhub.io/mysql-router/docs/e-interfaces?channel=8.4/edge).
+The legacy charm provided SQL endpoints `shared-db` (for the interface `mysql-shared`). The modern charm provides those old endpoint and a new endpoint `database` (for the interface `mysql_client`). Read more details about the available endpoints and interfaces [here](https://github.com/canonical/mysql-router-operators/blob/8.4/edge/machines/docs/explanation/e-interfaces.md).
 
 **Note**: Please choose one endpoint to use. No need to relate all of them simultaneously!
 

--- a/machines/docs/how-to/h-deploy-lxd.md
+++ b/machines/docs/how-to/h-deploy-lxd.md
@@ -10,7 +10,7 @@ multipass shell my-vm
 
 juju add-model mysql
 juju deploy mysql --channel 8.4/stable
-juju deploy mysql-router --channel 8.4/edge
+juju deploy mysql-router --channel 8.4/stable
 juju deploy mysql-test-app
 juju integrate mysql mysql-router
 juju integrate mysql-router mysql-test-app:database
@@ -24,8 +24,8 @@ Model  Controller  Cloud/Region         Version  SLA          Timestamp
 mysql  lxd         localhost/localhost  3.6.19   unsupported  11:57:33+02:00
 
 App             Version  Status  Scale  Charm           Channel     Rev  Exposed  Message
-mysql           8.4.7    active      1  mysql           8.4/edge    196  no       
-mysql-router    8.4.7    active      1  mysql-router    8.4/edge    119  no       
+mysql           8.4.10   active      1  mysql           8.4/stable  196  no       
+mysql-router    8.4.10   active      1  mysql-router    8.4/stable  119  no       
 mysql-test-app  0.0.2    active      1  mysql-test-app  stable       26  no       
 
 Unit               Workload  Agent  Machine  Public address  Ports           Message

--- a/machines/docs/how-to/h-enable-monitoring.md
+++ b/machines/docs/how-to/h-enable-monitoring.md
@@ -91,11 +91,11 @@ grafana     active  k8s    admin/cos.grafana
 loki        active  k8s    admin/cos.loki
 prometheus  active  k8s    admin/cos.prometheus
 
-App                      Version  Status  Scale  Charm                    Channel   Rev  Exposed  Message
-mysql                    8.4.7    active      1  mysql                    8.4/edge  196  no
-mysql-router             8.4.7    active      1  mysql-router             8.4/edge  153  no
-mysql-test-app           0.0.2    active      1  mysql-test-app           stable     36  no
-opentelemetry-collector           active      1  opentelemetry-collector  2/stable  316  no
+App                      Version  Status  Scale  Charm                    Channel     Rev  Exposed  Message
+mysql                    8.4.10   active      1  mysql                    8.4/stable       no
+mysql-router             8.4.10   active      1  mysql-router             8.4/stable       no
+mysql-test-app           0.0.2    active      1  mysql-test-app           stable       36  no
+opentelemetry-collector           active      1  opentelemetry-collector  2/stable    316  no
 
 Unit                          Workload  Agent  Machine  Public address  Ports           Message
 mysql-test-app/0*             active    idle         1  10.205.193.82

--- a/machines/docs/how-to/h-enable-tracing.md
+++ b/machines/docs/how-to/h-enable-tracing.md
@@ -100,8 +100,8 @@ SAAS       Status  Store  URL
 tempo-k8s  active  uk8s   admin/cos.tempo-k8s
 
 App             Version  Status  Scale  Charm           Channel      Rev  Exposed  Message
-mysql           8.4.7    active      1  mysql           8.4/edge     253  no       
-mysql-router    8.4.7    active      1  mysql-router    8.4/edge     216  no       
+mysql           8.4.10   active      1  mysql           8.4/stable        no       
+mysql-router    8.4.10   active      1  mysql-router    8.4/stable        no       
 mysql-test-app  0.0.2    active      1  mysql-test-app  latest/edge   46  no       Last written value=54713
 
 Unit               Workload  Agent  Machine  Public address  Ports           Message

--- a/machines/docs/how-to/h-external-access.md
+++ b/machines/docs/how-to/h-external-access.md
@@ -13,9 +13,9 @@ The steps below show you how to deploy and set up MySQL, MySQL Router, and Data 
 
 First, deploy all the charms:
 ```shell
-juju deploy mysql --channel 8.4/edge --trust
+juju deploy mysql --channel 8.4/stable --trust
+juju deploy mysql-router --channel 8.4/stable
 juju deploy data-integrator --config database-name=test_database
-juju deploy mysql-router --channel dpe/edge
 ```
 > Feel free to change `test_database` to your name of choice
 
@@ -77,9 +77,9 @@ The steps below show you how to deploy and set up MySQL, MySQL Router, Data Inte
 
 First, deploy all the charms
 ```shell
-juju deploy mysql --channel 8.4/edge --trust
-juju deploy -n 3 data-integrator --config database-name=test_database
-juju deploy mysql-router --channel dpe/edge
+juju deploy mysql --channel 8.4/stable --trust
+juju deploy mysql-router --channel 8.4/stable
+juju deploy data-integrator --config database-name=test_database -n 3 
 juju deploy hacluster
 ```
 > Note that the `data-integrator` requires a minimum of 3 nodes for this HACluster setup to work

--- a/machines/docs/reference/r-testing.md
+++ b/machines/docs/reference/r-testing.md
@@ -18,8 +18,8 @@ There are [a lot of test types](https://en.wikipedia.org/wiki/Software_testing) 
 ```shell
 juju add-model smoke-test
 
-juju deploy mysql --channel 8.4/edge --config profile=testing
-juju deploy mysql-router --channel 8.4/edge
+juju deploy mysql --channel 8.4/stable --config profile=testing
+juju deploy mysql-router --channel 8.4/stable
 juju relate mysql mysql-router
 
 juju add-unit mysql -n 2 # (optional)

--- a/machines/docs/tutorial/t-deploy-charm.md
+++ b/machines/docs/tutorial/t-deploy-charm.md
@@ -7,8 +7,8 @@ This is part of the [MySQL Router Tutorial](/t/12332). Please refer to this page
 To deploy Charmed MySQL + MySQL Router, all you need to do is run the following commands:
 
 ```shell
-juju deploy mysql --channel 8.4
-juju deploy mysql-router --channel 8.4/edge
+juju deploy mysql --channel 8.4/stable
+juju deploy mysql-router --channel 8.4/stable
 ```
 Juju will now fetch charms from [Charmhub](https://charmhub.io/) and begin deploying it to the LXD VMs. This process can take several minutes depending on how provisioned (RAM, CPU, etc) your machine is. You can track the progress by running:
 ```shell

--- a/machines/docs/tutorial/t-enable-security.md
+++ b/machines/docs/tutorial/t-enable-security.md
@@ -27,16 +27,16 @@ juju deploy self-signed-certificates --config ca-common-name="Tutorial CA"
 ```
 
 Wait until the `self-signed-certificates` is up and active, then use `juju status –watch 1s` to monitor the progress:
-
+    
 ```
 Model 	Controller  Cloud/Region     	Version  SLA      	Timestamp
 database  lxd     	localhost/localhost  3.6.19	 unsupported  18:47:51Z
 
-App                   	Version  Status  Scale  Charm                 	  Channel 	  Rev  Exposed  Message
-mysql                 	8.4.7    active  	1   mysql                 	  8.4/stable  196  no  	 
-mysql-router          	8.4.7    active  	1   mysql-router                          103  no  	 
-mysql-test-app        	0.0.2    active  	1   mysql-test-app        	  stable   	  36   no  	 
-self-signed-certificates         active  	1   self-signed-certificates  stable   	  72   no  	 
+App                   	  Version  Status  Scale  Charm                 	Channel 	Rev  Exposed  Message
+mysql                 	  8.4.10   active  	   1  mysql                     8.4/stable       no  	  
+mysql-router          	  8.4.10   active  	   1  mysql-router              8.4/stable       no  	  
+mysql-test-app        	  0.0.2    active  	   1  mysql-test-app            stable      36   no  	  
+self-signed-certificates           active  	   1  self-signed-certificates  stable      72   no  	  
 
 Unit                     	 Workload  Agent  Machine  Public address  Ports       	   Message
 mysql-test-app/0*        	 active	   idle         1  10.205.193.227             	 

--- a/machines/docs/tutorial/t-managing-units.md
+++ b/machines/docs/tutorial/t-managing-units.md
@@ -17,10 +17,10 @@ You can now watch the scaling process in live using: `juju status --watch 1s`. I
 Model     Controller  Cloud/Region        Version  SLA          Timestamp
 tutorial  overlord    microk8s/localhost  3.6.19   unsupported  22:48:57+01:00
 
-App               Version  Status  Scale  Charm             Channel   Rev  Address         Exposed  Message
-data-integrator            active      1  data-integrator   stable     13  10.152.183.142  no       
-mysql             8.4.7    active      1  mysql             8.4/edge  109  10.152.183.68   no       
-mysql-router      8.4.7    active      3  mysql-router      8.4/edge   68  10.152.183.52   no       
+App               Version  Status  Scale  Charm             Channel     Rev  Address         Exposed  Message
+data-integrator            active      1  data-integrator   stable       13  10.152.183.142  no       
+mysql             8.4.10   active      1  mysql             8.4/stable       10.152.183.68   no       
+mysql-router      8.4.10   active      3  mysql-router      8.4/stable       10.152.183.52   no       
 
 Unit                 Workload  Agent  Address     Ports  Message
 data-integrator/0*   active    idle   10.1.12.3          
@@ -36,10 +36,10 @@ juju scale-application mysql 3
 ```
 Make sure all units are active (using `juju status`):
 ```shell
-App               Version  Status  Scale  Charm             Channel   Rev  Address         Exposed  Message
-data-integrator            active      1  data-integrator   stable     13  10.152.183.142  no       
-mysql             8.4.7    active      3  mysql             8.4/edge  109  10.152.183.68   no       
-mysql-router      8.4.7    active      3  mysql-router      8.4/edge   68  10.152.183.52   no       
+App              Version  Status  Scale  Charm             Channel     Rev  Address         Exposed  Message
+data-integrator           active      1  data-integrator   stable       13  10.152.183.142  no       
+mysql            8.4.10   active      3  mysql             8.4/stable       10.152.183.68   no       
+mysql-router     8.4.10   active      3  mysql-router      8.4/stable       10.152.183.52   no       
 
 Unit                 Workload  Agent  Address     Ports  Message
 data-integrator/0*   active    idle   10.1.12.3          
@@ -63,10 +63,10 @@ You’ll know that the replica was successfully removed when `juju status --watc
 Model     Controller  Cloud/Region        Version  SLA          Timestamp
 tutorial  overlord    microk8s/localhost  3.6.19   unsupported  22:48:57+01:00
 
-App               Version  Status  Scale  Charm             Channel   Rev  Address         Exposed  Message
-data-integrator            active      1  data-integrator   stable     13  10.152.183.142  no       
-mysql             8.4.7    active      2  mysql             8.4/edge  109  10.152.183.68   no       
-mysql-router      8.4.7    active      2  mysql-router      8.4/edge   68  10.152.183.52   no       
+App              Version  Status  Scale  Charm             Channel     Rev  Address         Exposed  Message
+data-integrator           active      1  data-integrator   stable       13  10.152.183.142  no       
+mysql            8.4.10   active      2  mysql             8.4/stable       10.152.183.68   no       
+mysql-router     8.4.10   active      2  mysql-router      8.4/stable       10.152.183.52   no       
 
 Unit                 Workload  Agent  Address     Ports  Message
 data-integrator/0*   active    idle   10.1.12.3          

--- a/machines/terraform/variables.tf
+++ b/machines/terraform/variables.tf
@@ -30,7 +30,7 @@ variable "constraints" {
 variable "channel" {
   description = "Charm channel to deploy from"
   type        = string
-  default     = "8.4/edge"
+  default     = "8.4/stable"
 }
 
 variable "revision" {


### PR DESCRIPTION
This PR points all the documentation guides to `8.4/stable`. The Terraform default channels have also been updated.
